### PR TITLE
[codex] feat: switch workflow input contract to map

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ npm install agentic-task-kit
 
 ## 현재 포함 범위
 - sequential workflow engine
+- `Map<string, any>` workflow input contract
 - shard/kind 기반 in-memory memory engine
 - in-memory artifact store
 - execution event stream
@@ -173,6 +174,21 @@ const cycle = createCycle({
 ```
 
 `CYCLE_OPENAI_COMPATIBLE_CONFIG_PATH`, `CYCLE_OPENAI_CONFIG_PATH`, `OPENAI_CONFIG_PATH` 로도 경로를 지정할 수 있습니다.
+
+## Workflow Input Contract
+`Cycle.run()` 과 `WorkflowContext.input` 은 `Map<string, any>` 를 사용한다. plain object 입력은 `createWorkflowInput()` 으로 감싼다.
+
+```ts
+import { createCycle, createWorkflowInput } from "agentic-task-kit";
+
+const cycle = createCycle();
+const input = createWorkflowInput({
+  objective: "Generate a rollout summary",
+  priority: "high"
+});
+
+await cycle.run("report", input);
+```
 
 ## Memory Engine V2
 - `ctx.memory` 는 더 이상 단순 key/value `MemoryStore` 가 아니라 shard/hook/lifecycle 기반 `MemoryEngine` 이다.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -18,9 +18,11 @@ OpenAI-compatible provider 를 사용할 예정이면 추가 설정 파일이나
 ```ts
 import {
   createCycle,
+  createWorkflowInput,
   InMemoryArtifactStore,
   InMemoryMemoryEngine,
   Task,
+  workflowInputToPrettyJson,
   type TaskResult,
   type WorkflowContext,
   type WorkflowDefinition
@@ -41,7 +43,7 @@ class CaptureInputTask extends Task {
         workflowId: ctx.workflowId,
         currentStep: this.name,
         history: [],
-        contextSummary: JSON.stringify(ctx.input)
+        contextSummary: workflowInputToPrettyJson(ctx.input)
       },
       description: "Initial workflow summary",
       keywords: ["workflow", "input", "summary"],
@@ -125,9 +127,12 @@ const cycle = createCycle({
 
 cycle.register("quick-start", workflow);
 
-const { frame } = await cycle.run("quick-start", {
-  request: "Generate the first AX Workflow artifact."
-});
+const { frame } = await cycle.run(
+  "quick-start",
+  createWorkflowInput({
+    request: "Generate the first AX Workflow artifact."
+  }),
+);
 
 console.log(frame.status);
 ```
@@ -137,6 +142,7 @@ console.log(frame.status);
 - task 는 `Task` 를 상속하고 `name`, `memoryPhase`, `memoryTaskType`, `run()` 을 구현한다.
 - transition 은 `success`, `fail`, `retry`, `skip` 같은 status 별 다음 상태를 정의한다.
 - `Cycle` 은 workflow registry 와 runtime entrypoint 역할을 한다.
+- workflow input contract 는 `Map<string, any>` 이고, plain object 는 `createWorkflowInput()` 으로 감싼다.
 
 ## task 작성 규칙
 모든 task 는 memory metadata 를 명시해야 한다.
@@ -270,7 +276,7 @@ const completion = await ctx.ai.chat({
     {
       role: "user",
       content:
-        `Input: ${JSON.stringify(ctx.input)}\n\n` +
+        `Input: ${workflowInputToPrettyJson(ctx.input)}\n\n` +
         `Retrieved memory:\n${ctx.memoryContext?.assembledContext ?? "none"}`
     }
   ]
@@ -327,7 +333,7 @@ const cycle = createCycle({
 run 시점에는 `rag`, `memoryInjection`, 추가 observer 를 넣을 수 있다.
 
 ```ts
-await cycle.run("quick-start", input, {
+await cycle.run("quick-start", createWorkflowInput(input), {
   rag: [
     {
       id: "policy",

--- a/docs/memory-guide.md
+++ b/docs/memory-guide.md
@@ -157,7 +157,9 @@ default -> ["knowledge"]
 run 시작 전에 seed memory 를 넣고 싶으면 `memoryInjection` 과 `rag` 를 사용한다.
 
 ```ts
-await cycle.run("hook-workflow", input, {
+import { createWorkflowInput } from "agentic-task-kit";
+
+await cycle.run("hook-workflow", createWorkflowInput(input), {
   memoryInjection: [
     {
       id: "memory.user.summary.hook-user",

--- a/docs/openai-chat-api.md
+++ b/docs/openai-chat-api.md
@@ -37,6 +37,8 @@ const cycle = createCycle({
 task 에서는 `ctx.ai.chat()` 로 호출한다.
 
 ```ts
+import { workflowInputToPrettyJson } from "agentic-task-kit";
+
 const completion = await ctx.ai.chat({
   messages: [
     {
@@ -45,7 +47,7 @@ const completion = await ctx.ai.chat({
     },
     {
       role: "user",
-      content: JSON.stringify(ctx.input)
+      content: workflowInputToPrettyJson(ctx.input)
     }
   ]
 });

--- a/sample-project/src/main-stream.ts
+++ b/sample-project/src/main-stream.ts
@@ -6,6 +6,7 @@ import {
   createCLIRenderer,
   createCycle,
   createOpenAICompatibleChatProvider,
+  createWorkflowInput,
   loadOpenAICompatibleChatProviderOptionsFromConfigFile,
   OpenAIStreamingSummaryWorkflow,
   resolveOpenAICompatibleChatConfigPath,
@@ -119,12 +120,15 @@ const cycle = createCycle({
 
 cycle.register("openai-streaming-summary", OpenAIStreamingSummaryWorkflow);
 
-const { frame } = await cycle.run("openai-streaming-summary", {
-  product: "Cycle",
-  objective: "Summarize OpenAI-compatible configuration support for a sample host application.",
-  configPath,
-  ...(requestHeaders ? { requestHeaders } : {})
-});
+const { frame } = await cycle.run(
+  "openai-streaming-summary",
+  createWorkflowInput({
+    product: "Cycle",
+    objective: "Summarize OpenAI-compatible configuration support for a sample host application.",
+    configPath,
+    ...(requestHeaders ? { requestHeaders } : {})
+  })
+);
 
 process.stdout.write(
   `Sample streaming project finished with status=${frame.status} completedTasks=${frame.completedTasks.join(",")}\n`

--- a/sample-project/src/main.ts
+++ b/sample-project/src/main.ts
@@ -6,6 +6,7 @@ import {
   createCLIRenderer,
   createCycle,
   createOpenAICompatibleChatProvider,
+  createWorkflowInput,
   loadOpenAICompatibleChatProviderOptionsFromConfigFile,
   OpenAISummaryWorkflow,
   resolveOpenAICompatibleChatConfigPath,
@@ -119,12 +120,15 @@ const cycle = createCycle({
 
 cycle.register("openai-summary", OpenAISummaryWorkflow);
 
-const { frame } = await cycle.run("openai-summary", {
-  product: "Cycle",
-  objective: "Summarize OpenAI-compatible configuration support for a sample host application.",
-  configPath,
-  ...(requestHeaders ? { requestHeaders } : {})
-});
+const { frame } = await cycle.run(
+  "openai-summary",
+  createWorkflowInput({
+    product: "Cycle",
+    objective: "Summarize OpenAI-compatible configuration support for a sample host application.",
+    configPath,
+    ...(requestHeaders ? { requestHeaders } : {})
+  })
+);
 
 process.stdout.write(
   `Sample project finished with status=${frame.status} completedTasks=${frame.completedTasks.join(",")}\n`

--- a/scripts/run-consumer-example.ts
+++ b/scripts/run-consumer-example.ts
@@ -1,12 +1,15 @@
 import {
   createCLIRenderer,
   createCycle,
+  createWorkflowInput,
+  getWorkflowInputValue,
   InMemoryArtifactStore,
   InMemoryMemoryEngine,
   Task,
   type CLIRendererOptions,
   type TaskResult,
   type UserMemory,
+  type WorkflowInput,
   type WorkflowContext,
   type WorkflowDefinition,
   type WorkflowMemory
@@ -37,13 +40,31 @@ function resolveRendererOptions(): CLIRendererOptions {
   };
 }
 
+function requireBriefingInput(input: WorkflowInput): BriefingInput {
+  const customerName = getWorkflowInputValue<string>(input, "customerName");
+  const request = getWorkflowInputValue<string>(input, "request");
+  const priority = getWorkflowInputValue<BriefingInput["priority"]>(input, "priority");
+  const constraints = getWorkflowInputValue<string[]>(input, "constraints");
+
+  if (!customerName || !request || !priority || !Array.isArray(constraints)) {
+    throw new Error("Briefing workflow input is missing required fields.");
+  }
+
+  return {
+    customerName,
+    request,
+    priority,
+    constraints
+  };
+}
+
 class CaptureRequestTask extends Task {
   name = "captureRequest";
   memoryPhase = "PLANNING" as const;
   memoryTaskType = "user" as const;
 
   async run(ctx: WorkflowContext): Promise<TaskResult> {
-    const input = ctx.input as BriefingInput;
+    const input = requireBriefingInput(ctx.input);
     ctx.log.info("Capturing customer request", {
       customerName: input.customerName,
       priority: input.priority
@@ -86,7 +107,7 @@ class DraftPlanTask extends Task {
 
   async run(ctx: WorkflowContext): Promise<TaskResult> {
     ctx.log.info("Drafting action plan");
-    const input = ctx.input as BriefingInput;
+    const input = requireBriefingInput(ctx.input);
     const requestRecord = await ctx.memory.get(`memory.user.summary.${input.customerName}`);
     const request = requestRecord?.payload as UserMemory | undefined;
 
@@ -194,12 +215,12 @@ const cycle = createCycle({
 
 cycle.register("customer-briefing", ConsumerWorkflow);
 
-const input: BriefingInput = {
+const input = createWorkflowInput({
   customerName: "Skyend Retail",
   request: "Create a rollout briefing for the first AX Workflow MVP pilot.",
   priority: "high",
   constraints: ["Keep the first release sequential only", "Show CLI line mode output"]
-};
+});
 
 const { frame } = await cycle.run("customer-briefing", input, {
   rag: [

--- a/scripts/run-example.ts
+++ b/scripts/run-example.ts
@@ -1,4 +1,9 @@
-import { createCycle, createCLIRenderer, ReportWorkflow } from "../src/index.js";
+import {
+  createCLIRenderer,
+  createCycle,
+  createWorkflowInput,
+  ReportWorkflow
+} from "../src/index.js";
 
 const requestedMode = process.env.CYCLE_RENDER_MODE as
   | "off"
@@ -36,16 +41,20 @@ const cycle = createCycle({
 
 cycle.register("report", ReportWorkflow);
 
-const { frame } = await cycle.run("report", {
-  text: "Cycle should provide a reusable foundation for AX Workflow with memory, events, logs, and CLI rendering."
-}, {
-  rag: [
-    {
-      id: "design",
-      text: "AX Workflow libraries should expose clear package APIs and observable execution events."
-    }
-  ]
-});
+const { frame } = await cycle.run(
+  "report",
+  createWorkflowInput({
+    text: "Cycle should provide a reusable foundation for AX Workflow with memory, events, logs, and CLI rendering."
+  }),
+  {
+    rag: [
+      {
+        id: "design",
+        text: "AX Workflow libraries should expose clear package APIs and observable execution events."
+      }
+    ]
+  }
+);
 
 process.stdout.write(
   `Example finished with status=${frame.status} completedTasks=${frame.completedTasks.join(",")}\n`

--- a/scripts/run-openai-example.ts
+++ b/scripts/run-openai-example.ts
@@ -4,6 +4,7 @@ import {
   createCLIRenderer,
   createCycle,
   createOpenAICompatibleChatProvider,
+  createWorkflowInput,
   loadOpenAICompatibleChatProviderOptionsFromConfigFile,
   OpenAISummaryWorkflow,
   resolveOpenAICompatibleChatConfigPath,
@@ -137,15 +138,18 @@ const cycle = createCycle({
 
 cycle.register("openai-summary", OpenAISummaryWorkflow);
 
-const { frame } = await cycle.run("openai-summary", {
-  objective: "Summarize the current MVP rollout status for the first customer pilot.",
-  constraints: [
-    "Keep the workflow sequential",
-    "Report CLI renderer support",
-    "Mention provider config support"
-  ],
-  ...(requestHeaders ? { requestHeaders } : {})
-});
+const { frame } = await cycle.run(
+  "openai-summary",
+  createWorkflowInput({
+    objective: "Summarize the current MVP rollout status for the first customer pilot.",
+    constraints: [
+      "Keep the workflow sequential",
+      "Report CLI renderer support",
+      "Mention provider config support"
+    ],
+    ...(requestHeaders ? { requestHeaders } : {})
+  })
+);
 
 process.stdout.write(
   `OpenAI-compatible example finished with status=${frame.status} completedTasks=${frame.completedTasks.join(",")}\n`

--- a/scripts/run-openai-streaming-example.ts
+++ b/scripts/run-openai-streaming-example.ts
@@ -4,6 +4,7 @@ import {
   createCLIRenderer,
   createCycle,
   createOpenAICompatibleChatProvider,
+  createWorkflowInput,
   loadOpenAICompatibleChatProviderOptionsFromConfigFile,
   OpenAIStreamingSummaryWorkflow,
   resolveOpenAICompatibleChatConfigPath,
@@ -136,15 +137,18 @@ const cycle = createCycle({
 
 cycle.register("openai-streaming-summary", OpenAIStreamingSummaryWorkflow);
 
-const { frame } = await cycle.run("openai-streaming-summary", {
-  objective: "Summarize the current MVP rollout status for the first customer pilot.",
-  constraints: [
-    "Keep the workflow sequential",
-    "Report CLI renderer support",
-    "Mention provider config support"
-  ],
-  ...(requestHeaders ? { requestHeaders } : {})
-});
+const { frame } = await cycle.run(
+  "openai-streaming-summary",
+  createWorkflowInput({
+    objective: "Summarize the current MVP rollout status for the first customer pilot.",
+    constraints: [
+      "Keep the workflow sequential",
+      "Report CLI renderer support",
+      "Mention provider config support"
+    ],
+    ...(requestHeaders ? { requestHeaders } : {})
+  })
+);
 
 process.stdout.write(
   `OpenAI-compatible streaming example finished with status=${frame.status} completedTasks=${frame.completedTasks.join(",")}\n`

--- a/src/cycle.ts
+++ b/src/cycle.ts
@@ -25,6 +25,7 @@ import type {
   RunOptions,
   TaskResult,
   Transition,
+  WorkflowInput,
   WorkflowContext,
   WorkflowDefinition
 } from "./types.js";
@@ -187,7 +188,7 @@ class DefaultCycle implements Cycle {
 
   async run(
     key: string,
-    input: unknown,
+    input: WorkflowInput,
     options: RunOptions = {},
   ): Promise<{ frame: ExecutionFrame }> {
     const workflow = this.workflows.get(key);

--- a/src/examples/openai-streaming-summary-workflow.ts
+++ b/src/examples/openai-streaming-summary-workflow.ts
@@ -6,21 +6,17 @@ import type {
   WorkflowDefinition,
   WorkflowMemory
 } from "../types.js";
+import {
+  getWorkflowInputValue,
+  workflowInputToPrettyJson
+} from "../workflow-input.js";
 
-function toInputText(input: unknown): string {
-  if (typeof input === "string") {
-    return input;
-  }
-
-  return JSON.stringify(input, null, 2);
+function toInputText(input: WorkflowContext["input"]): string {
+  return workflowInputToPrettyJson(input);
 }
 
-function resolveRequestHeaders(input: unknown): AIHTTPHeaders | undefined {
-  if (!input || typeof input !== "object" || !("requestHeaders" in input)) {
-    return undefined;
-  }
-
-  const requestHeaders = input.requestHeaders;
+function resolveRequestHeaders(input: WorkflowContext["input"]): AIHTTPHeaders | undefined {
+  const requestHeaders = getWorkflowInputValue<Record<string, unknown>>(input, "requestHeaders");
   if (!requestHeaders || typeof requestHeaders !== "object" || Array.isArray(requestHeaders)) {
     return undefined;
   }

--- a/src/examples/openai-summary-workflow.ts
+++ b/src/examples/openai-summary-workflow.ts
@@ -5,13 +5,10 @@ import type {
   WorkflowDefinition,
   WorkflowMemory
 } from "../types.js";
+import { workflowInputToPrettyJson } from "../workflow-input.js";
 
-function toInputText(input: unknown): string {
-  if (typeof input === "string") {
-    return input;
-  }
-
-  return JSON.stringify(input, null, 2);
+function toInputText(input: WorkflowContext["input"]): string {
+  return workflowInputToPrettyJson(input);
 }
 
 class GenerateSummaryTask extends Task {

--- a/src/examples/report-workflow.ts
+++ b/src/examples/report-workflow.ts
@@ -5,6 +5,10 @@ import type {
   WorkflowContext,
   WorkflowMemory
 } from "../types.js";
+import {
+  getWorkflowInputValue,
+  workflowInputToPrettyJson
+} from "../workflow-input.js";
 
 function summarizeText(text: string): string {
   const trimmed = text.replace(/\s+/g, " ").trim();
@@ -22,9 +26,8 @@ class AnalyzeTask extends Task {
 
   async run(ctx: WorkflowContext): Promise<TaskResult> {
     const sourceText =
-      typeof ctx.input === "string"
-        ? ctx.input
-        : JSON.stringify(ctx.input, null, 2);
+      getWorkflowInputValue<string>(ctx.input, "text") ??
+      workflowInputToPrettyJson(ctx.input);
 
     ctx.log.info("Starting analysis", {
       inputLength: sourceText.length

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,14 @@ export {
 } from "./openai-provider.js";
 export { Task } from "./task.js";
 export { createCLIRenderer } from "./renderer.js";
+export {
+  createWorkflowInput,
+  getWorkflowInputValue,
+  requireWorkflowInputValue,
+  toSerializableValue,
+  workflowInputToObject,
+  workflowInputToPrettyJson
+} from "./workflow-input.js";
 export { ReportWorkflow } from "./examples/report-workflow.js";
 export { OpenAISummaryWorkflow } from "./examples/openai-summary-workflow.js";
 export { OpenAIStreamingSummaryWorkflow } from "./examples/openai-streaming-summary-workflow.js";
@@ -95,5 +103,6 @@ export type {
   TaskStatus,
   Transition,
   WorkflowContext,
+  WorkflowInput,
   WorkflowDefinition
 } from "./types.js";

--- a/src/memory.ts
+++ b/src/memory.ts
@@ -29,6 +29,7 @@ import type {
   WorkflowMemory,
   WriteDisposition
 } from "./types.js";
+import { toSerializableValue } from "./workflow-input.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const DEFAULT_MAX_CONTEXT_TOKENS = 8_192;
@@ -1095,7 +1096,7 @@ function stringifyPayload(payload: MemoryRecord["payload"], description: string)
 
 function safeJson(value: unknown): string {
   try {
-    return JSON.stringify(value);
+    return JSON.stringify(toSerializableValue(value));
   } catch {
     return String(value);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,7 @@
 export type TaskStatus = "success" | "fail" | "retry" | "skip" | (string & {});
 
+export type WorkflowInput = Map<string, any>;
+
 export type TaskResult<T = unknown> = {
   status: TaskStatus;
   output?: T;
@@ -181,7 +183,7 @@ export type BeforeStepInput = {
   taskName: string;
   taskType: MemoryTaskType;
   phase: MemoryPhase;
-  input: unknown;
+  input: WorkflowInput;
   now: number;
 };
 
@@ -548,7 +550,7 @@ export type ExecutionFrame = {
 export interface WorkflowContext {
   workflowId: string;
   runId: string;
-  input: unknown;
+  input: WorkflowInput;
   session: AISession;
   ai: AIProvider;
   memory: MemoryEngine;
@@ -567,7 +569,7 @@ export type RunOptions = {
 
 export interface Cycle {
   register(key: string, workflow: WorkflowDefinition): void;
-  run(key: string, input: unknown, options?: RunOptions): Promise<{ frame: ExecutionFrame }>;
+  run(key: string, input: WorkflowInput, options?: RunOptions): Promise<{ frame: ExecutionFrame }>;
 }
 
 export type CycleOptions = {

--- a/src/workflow-input.ts
+++ b/src/workflow-input.ts
@@ -1,0 +1,115 @@
+import type { WorkflowInput } from "./types.js";
+
+export type WorkflowInputInit =
+  | WorkflowInput
+  | Record<string, any>
+  | Iterable<readonly [string, any]>
+  | undefined;
+
+export function createWorkflowInput(init?: WorkflowInputInit): WorkflowInput {
+  if (!init) {
+    return new Map<string, any>();
+  }
+
+  if (init instanceof Map) {
+    return new Map<string, any>(init);
+  }
+
+  if (Symbol.iterator in Object(init) && !isPlainObject(init)) {
+    return new Map<string, any>(init as Iterable<readonly [string, any]>);
+  }
+
+  return new Map<string, any>(Object.entries(init));
+}
+
+export function workflowInputToObject(input: WorkflowInput): Record<string, any> {
+  return Object.fromEntries(input);
+}
+
+export function getWorkflowInputValue<T = any>(
+  input: WorkflowInput,
+  key: string,
+): T | undefined {
+  return input.get(key) as T | undefined;
+}
+
+export function requireWorkflowInputValue<T = any>(
+  input: WorkflowInput,
+  key: string,
+): T {
+  if (!input.has(key)) {
+    throw new Error(`Workflow input is missing "${key}".`);
+  }
+
+  return input.get(key) as T;
+}
+
+export function workflowInputToPrettyJson(input: WorkflowInput): string {
+  return JSON.stringify(toSerializableValue(input), null, 2);
+}
+
+export function toSerializableValue(value: unknown): unknown {
+  return serializeValue(value, new WeakSet<object>());
+}
+
+function serializeValue(value: unknown, seen: WeakSet<object>): unknown {
+  if (value instanceof Map) {
+    return Object.fromEntries(
+      [...value.entries()].map(([key, entryValue]) => [
+        String(key),
+        serializeValue(entryValue, seen)
+      ]),
+    );
+  }
+
+  if (value instanceof Set) {
+    return [...value.values()].map((entry) => serializeValue(entry, seen));
+  }
+
+  if (Array.isArray(value)) {
+    return value.map((entry) => serializeValue(entry, seen));
+  }
+
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return {
+      name: value.name,
+      message: value.message,
+      ...(value.stack ? { stack: value.stack } : {})
+    };
+  }
+
+  if (typeof value === "bigint") {
+    return value.toString();
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  if (seen.has(value)) {
+    return "[Circular]";
+  }
+
+  seen.add(value);
+  const serialized = Object.fromEntries(
+    Object.entries(value).map(([key, entryValue]) => [
+      key,
+      serializeValue(entryValue, seen)
+    ]),
+  );
+  seen.delete(value);
+  return serialized;
+}
+
+function isPlainObject(value: unknown): value is Record<string, any> {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCLIRenderer,
   createCycle,
+  createWorkflowInput,
   InMemoryArtifactStore,
   InMemoryMemoryEngine,
   OpenAISummaryWorkflow,
@@ -83,9 +84,12 @@ describe("AI provider integration", () => {
     });
 
     cycle.register("openai-summary", OpenAISummaryWorkflow);
-    const result = await cycle.run("openai-summary", {
-      objective: "Summarize AI configuration support in the library."
-    });
+    const result = await cycle.run(
+      "openai-summary",
+      createWorkflowInput({
+        objective: "Summarize AI configuration support in the library."
+      }),
+    );
 
     expect(result.frame.status).toBe("success");
     expect(result.frame.completedTasks).toEqual(["generateSummary", "publishSummary"]);

--- a/tests/cycle.test.ts
+++ b/tests/cycle.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCLIRenderer,
   createCycle,
+  createWorkflowInput,
   InMemoryArtifactStore,
   InMemoryMemoryEngine,
   ReportWorkflow,
@@ -40,7 +41,9 @@ describe("Cycle foundation MVP", () => {
     cycle.register("report", ReportWorkflow);
     const result = await cycle.run(
       "report",
-      "Cycle foundation MVP should produce observable workflow results.",
+      createWorkflowInput({
+        text: "Cycle foundation MVP should produce observable workflow results."
+      }),
     );
 
     expect(result.frame.status).toBe("success");
@@ -111,7 +114,7 @@ describe("Cycle foundation MVP", () => {
     });
 
     cycle.register("failing-report", FailingWorkflow);
-    const result = await cycle.run("failing-report", {});
+    const result = await cycle.run("failing-report", createWorkflowInput());
 
     expect(result.frame.status).toBe("fail");
     expect(output).toContain("task.failed failTask Validation mismatch: missing required field");
@@ -176,9 +179,9 @@ describe("Cycle foundation MVP", () => {
 
     const result = await cycle.run(
       "hook-workflow",
-      {
+      createWorkflowInput({
         request: "demo"
-      },
+      }),
       {
         memoryInjection: [
           {

--- a/tests/memory.test.ts
+++ b/tests/memory.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  createWorkflowInput,
   DeterministicHashEmbeddingProvider,
   InMemoryKVStore,
   InMemoryMemoryEngine,
@@ -147,9 +148,9 @@ describe("Memory Engine V2", () => {
         taskName: "validate",
         taskType: "debug",
         phase: "RECOVERY",
-        input: {
+        input: createWorkflowInput({
           index,
-        },
+        }),
         result: {
           status: "fail",
           error: {


### PR DESCRIPTION
## Summary
- switch the workflow runtime input contract to Map<string, any>
- add workflow input helpers and Map-aware serialization for memory retrieval/logging
- migrate examples, tests, and sample-project to the new input contract

## Verification
- npm run typecheck
- npm test
- npm run build
- npm run example
- npm run example:consumer