### PR TITLE
[codex] add sub-workflow snapshots and ink flowchart

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,55 @@ const input = createWorkflowInput({
 await cycle.run("report", input);
 ```
 
+## Run Result Snapshot
+`Cycle.run()` 은 `frame` 뿐 아니라 실행 종료 시점의 memory/artifact/history snapshot 도 함께 반환한다.
+
+```ts
+const result = await cycle.run("report", input);
+
+console.log(result.frame.status);
+console.log(result.memory.records.length);
+console.log(result.artifacts.artifacts.map((artifact) => artifact.name));
+console.log(result.history.events.map((event) => event.type));
+```
+
+## Sub Workflow And Live Tracking
+task 실행 중에는 `ctx.runSubWorkflow()` 로 등록된 다른 workflow 를 이어서 실행할 수 있고, `createExecutionHistoryTracker()` 로 실시간 실행 이력을 구독할 수 있다.
+
+```ts
+import {
+  Task,
+  createCycle,
+  createExecutionHistoryTracker,
+  createWorkflowInput,
+  type TaskResult,
+  type WorkflowContext
+} from "agentic-task-kit";
+
+const tracker = createExecutionHistoryTracker();
+tracker.subscribe((snapshot) => {
+  console.log(snapshot.events.length, snapshot.taskLogs.length);
+});
+
+class ParentTask extends Task {
+  name = "parent";
+  memoryPhase = "EXECUTION" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    const child = await ctx.runSubWorkflow("child", createWorkflowInput(), {
+      branchId: "branch.child",
+      summary: "run child workflow"
+    });
+
+    return {
+      status: "success",
+      output: child.frame.status
+    };
+  }
+}
+```
+
 ## Memory Engine V2
 - `ctx.memory` 는 더 이상 단순 key/value `MemoryStore` 가 아니라 shard/hook/lifecycle 기반 `MemoryEngine` 이다.
 - 모든 task 는 `memoryPhase` 와 `memoryTaskType` 을 명시해야 하고, runtime 이 자동으로 `beforeStep()` retrieval 과 `afterStep()` write 를 호출한다.

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -137,6 +137,16 @@ const { frame } = await cycle.run(
 console.log(frame.status);
 ```
 
+`Cycle.run()` 반환값에는 `frame` 외에도 run 범위의 memory/artifact/history snapshot 이 포함된다.
+
+```ts
+const result = await cycle.run("quick-start", createWorkflowInput(input));
+
+console.log(result.memory.records.length);
+console.log(result.artifacts.artifacts.map((artifact) => artifact.name));
+console.log(result.history.events.map((event) => event.type));
+```
+
 ## 핵심 개념
 - workflow 는 `WorkflowDefinition` 으로 정의한다.
 - task 는 `Task` 를 상속하고 `name`, `memoryPhase`, `memoryTaskType`, `run()` 을 구현한다.

--- a/package.json
+++ b/package.json
@@ -27,8 +27,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "clean": "rm -rf dist",
-    "clean:all-in-one": "rm -rf .npm-package",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\"",
+    "clean:all-in-one": "node -e \"require('node:fs').rmSync('.npm-package', { recursive: true, force: true })\"",
     "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:bundle": "node ./scripts/build-package.mjs",
     "build:all-in-one": "npm run build && node ./scripts/build-all-in-one-package.mjs",

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -24,6 +24,21 @@ Ink TUI mode:
 OPENAI_API_KEY=your_key_here CYCLE_RENDER_MODE=ink npm run start
 ```
 
+sub workflow example:
+```bash
+npm run start:sub
+```
+
+sub workflow example in line mode:
+```bash
+npm run start:sub:line
+```
+
+sub workflow example in Ink mode:
+```bash
+npm run start:sub:ink
+```
+
 streaming workflow:
 ```bash
 OPENAI_API_KEY=your_key_here npm run start:stream
@@ -55,3 +70,12 @@ Ink TUI 에서 provider debug 로그까지 우측 패널에 함께 보려면:
 ```bash
 OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_RENDER_MODE=ink npm run start
 ```
+
+## Sub Workflow Example
+`src/main-sub-workflow.ts` 는 parent workflow 가 `ctx.runSubWorkflow()` 로 child workflow 를 branch 로 호출하는 예제다.
+
+- parent workflow: `release-orchestration`
+- child workflow: `service-analysis`
+- branch id: `branch.service-analysis`
+
+Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행이 끝난 뒤에도 Ink 세션은 유지되며, `Ctrl+C` 입력이 들어오면 터미널 출력을 오염시키지 않게 Ink session 을 닫고 프로세스를 종료한다.

--- a/sample-project/package.json
+++ b/sample-project/package.json
@@ -10,10 +10,14 @@
     "start": "tsx ./src/main.ts",
     "start:line": "CYCLE_LIVE=0 tsx ./src/main.ts",
     "start:ink": "CYCLE_RENDER_MODE=ink tsx ./src/main.ts",
-    "start:stream": "tsx ./src/main-stream.ts"
+    "start:stream": "tsx ./src/main-stream.ts",
+    "start:sub": "tsx ./src/main-sub-workflow.ts",
+    "start:sub:line": "CYCLE_LIVE=0 tsx ./src/main-sub-workflow.ts",
+    "start:sub:ink": "cross-env CYCLE_RENDER_MODE=ink tsx ./src/main-sub-workflow.ts"
   },
   "dependencies": {
-    "agentic-task-kit": "file:.."
+    "agentic-task-kit": "file:..",
+    "cross-env": "^10.1.0"
   },
   "devDependencies": {
     "@types/node": "^25.5.0",

--- a/sample-project/src/main-sub-workflow.ts
+++ b/sample-project/src/main-sub-workflow.ts
@@ -1,0 +1,350 @@
+import {
+  createCLIRenderer,
+  createCycle,
+  createWorkflowInput,
+  InMemoryArtifactStore,
+  InMemoryMemoryEngine,
+  Task,
+  type CLIRendererOptions,
+  type CycleRunResult,
+  type TaskResult,
+  type WorkflowContext,
+  type WorkflowDefinition,
+  type WorkflowInput,
+  type WorkflowMemory
+} from "agentic-task-kit";
+
+type ReleaseInput = {
+  product: string;
+  objective: string;
+  services: string[];
+  environment: string;
+};
+
+function resolveRendererOptions(): CLIRendererOptions {
+  const requestedMode = process.env.CYCLE_RENDER_MODE as CLIRendererOptions["mode"];
+  const requestedLogLevel = process.env.CYCLE_LOG_LEVEL as CLIRendererOptions["logLevel"];
+
+  if (requestedMode) {
+    return {
+      enabled: process.env.CYCLE_LIVE !== "0",
+      mode: requestedMode,
+      ...(requestedLogLevel ? { logLevel: requestedLogLevel } : {})
+    };
+  }
+
+  return {
+    enabled: process.env.CYCLE_LIVE !== "0",
+    ...(requestedLogLevel ? { logLevel: requestedLogLevel } : {})
+  };
+}
+
+function requireReleaseInput(input: WorkflowInput): ReleaseInput {
+  const object = Object.fromEntries(input.entries()) as Partial<ReleaseInput>;
+
+  if (
+    typeof object.product !== "string" ||
+    typeof object.objective !== "string" ||
+    !Array.isArray(object.services) ||
+    object.services.some((service) => typeof service !== "string") ||
+    typeof object.environment !== "string"
+  ) {
+    throw new Error("Release workflow input is missing required fields.");
+  }
+
+  return object as ReleaseInput;
+}
+
+function isPersistentInkRenderer(options: CLIRendererOptions): boolean {
+  return options.enabled !== false && options.mode === "ink";
+}
+
+class PrepareReleaseTask extends Task {
+  name = "prepareRelease";
+  memoryPhase = "PLANNING" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    const input = requireReleaseInput(ctx.input);
+    ctx.log.info("Preparing parent workflow release plan", {
+      product: input.product,
+      services: input.services.length
+    });
+
+    const summary = [
+      `${input.product} rollout objective: ${input.objective}.`,
+      `Target environment: ${input.environment}.`,
+      `Services: ${input.services.join(", ")}.`
+    ].join(" ");
+
+    await ctx.memory.write({
+      id: `memory.workflow.summary.${ctx.workflowId}.prepare`,
+      shard: "workflow",
+      kind: "summary",
+      payload: {
+        workflowId: ctx.workflowId,
+        currentStep: this.name,
+        history: [],
+        contextSummary: summary
+      } satisfies WorkflowMemory,
+      description: "Parent release workflow summary",
+      keywords: ["release", "parent", "summary"],
+      importance: 0.91,
+      workflowId: ctx.workflowId,
+      runId: ctx.runId,
+      sourceTask: this.name,
+      phase: this.memoryPhase,
+      taskType: this.memoryTaskType
+    });
+
+    return {
+      status: "success",
+      output: {
+        summary
+      }
+    };
+  }
+}
+
+class AnalyzeServicesTask extends Task {
+  name = "analyzeServices";
+  memoryPhase = "EXECUTION" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    const input = requireReleaseInput(ctx.input);
+    ctx.log.info("Launching child workflow branch", {
+      branchId: "branch.service-analysis"
+    });
+
+    const child = await ctx.runSubWorkflow(
+      "service-analysis",
+      createWorkflowInput({
+        product: input.product,
+        services: input.services,
+        environment: input.environment
+      }),
+      {
+        branchId: "branch.service-analysis",
+        summary: "Analyze service rollout branches"
+      }
+    );
+
+    return {
+      status: child.frame.status === "success" ? "success" : "fail",
+      ...(child.frame.status === "success"
+        ? {
+            output: {
+              childWorkflowId: child.frame.workflowId,
+              childArtifacts: child.artifacts.artifacts.map((artifact) => artifact.name),
+              childCompletedTasks: child.frame.completedTasks
+            }
+          }
+        : {
+            error: {
+              message: child.frame.errors[child.frame.errors.length - 1] ?? "Child workflow failed"
+            }
+          })
+    };
+  }
+}
+
+class PublishReleaseTask extends Task {
+  name = "publishRelease";
+  memoryPhase = "REFLECTION" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    const input = requireReleaseInput(ctx.input);
+    const artifact = await ctx.artifacts.create({
+      name: "release-rollout-summary.md",
+      mimeType: "text/markdown",
+      bytes: new TextEncoder().encode(
+        [
+          "# Release Rollout Summary",
+          "",
+          `- Product: ${input.product}`,
+          `- Objective: ${input.objective}`,
+          `- Environment: ${input.environment}`,
+          `- Retrieved Context: ${ctx.memoryContext?.assembledContext ?? "none"}`
+        ].join("\n")
+      )
+    });
+
+    ctx.log.success("Published release rollout summary", {
+      artifactId: artifact.artifactId
+    });
+
+    return {
+      status: "success",
+      output: artifact
+    };
+  }
+}
+
+class ServiceScanTask extends Task {
+  name = "scanServices";
+  memoryPhase = "PLANNING" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    const input = Object.fromEntries(ctx.input.entries()) as {
+      product: string;
+      services: string[];
+      environment: string;
+    };
+
+    ctx.log.info("Scanning child workflow services", {
+      serviceCount: input.services.length
+    });
+
+    await ctx.memory.write({
+      id: `memory.workflow.summary.${ctx.workflowId}.scan`,
+      shard: "workflow",
+      kind: "summary",
+      payload: {
+        workflowId: ctx.workflowId,
+        currentStep: this.name,
+        history: [],
+        contextSummary: `${input.product} services scanned for ${input.environment}: ${input.services.join(", ")}`
+      } satisfies WorkflowMemory,
+      description: "Child workflow service scan summary",
+      keywords: ["child", "services", "scan"],
+      importance: 0.9,
+      workflowId: ctx.workflowId,
+      runId: ctx.runId,
+      sourceTask: this.name,
+      phase: this.memoryPhase,
+      taskType: this.memoryTaskType
+    });
+
+    return {
+      status: "success",
+      output: {
+        services: input.services
+      }
+    };
+  }
+}
+
+class GenerateChecklistTask extends Task {
+  name = "generateChecklist";
+  memoryPhase = "EXECUTION" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    const input = Object.fromEntries(ctx.input.entries()) as {
+      product: string;
+      services: string[];
+      environment: string;
+    };
+
+    const checklist = input.services.map((service, index) =>
+      `${index + 1}. Validate ${service} deployment in ${input.environment}`
+    );
+
+    const artifact = await ctx.artifacts.create({
+      name: "service-analysis-checklist.md",
+      mimeType: "text/markdown",
+      bytes: new TextEncoder().encode(
+        [
+          `# ${input.product} Service Analysis Checklist`,
+          "",
+          ...checklist
+        ].join("\n")
+      )
+    });
+
+    ctx.log.success("Generated child workflow checklist", {
+      artifactId: artifact.artifactId
+    });
+
+    return {
+      status: "success",
+      output: {
+        checklist,
+        artifactId: artifact.artifactId
+      }
+    };
+  }
+}
+
+const ParentWorkflow: WorkflowDefinition = {
+  name: "release-orchestration",
+  start: "prepareRelease",
+  end: "end",
+  tasks: {
+    prepareRelease: new PrepareReleaseTask(),
+    analyzeServices: new AnalyzeServicesTask(),
+    publishRelease: new PublishReleaseTask()
+  },
+  transitions: {
+    prepareRelease: {
+      success: "analyzeServices",
+      fail: "end"
+    },
+    analyzeServices: {
+      success: "publishRelease",
+      fail: "end"
+    },
+    publishRelease: {
+      success: "end",
+      fail: "end"
+    }
+  }
+};
+
+const ChildWorkflow: WorkflowDefinition = {
+  name: "service-analysis",
+  start: "scanServices",
+  end: "end",
+  tasks: {
+    scanServices: new ServiceScanTask(),
+    generateChecklist: new GenerateChecklistTask()
+  },
+  transitions: {
+    scanServices: {
+      success: "generateChecklist",
+      fail: "end"
+    },
+    generateChecklist: {
+      success: "end",
+      fail: "end"
+    }
+  }
+};
+
+function printResult(result: CycleRunResult): void {
+  const artifactNames = result.artifacts.artifacts.map((artifact) => artifact.name).join(", ") || "none";
+  process.stdout.write(
+    `Sub workflow example finished with status=${result.frame.status} completedTasks=${result.frame.completedTasks.join(",")} artifacts=${artifactNames} memoryRecords=${result.memory.records.length}\n`
+  );
+}
+
+const rendererOptions = resolveRendererOptions();
+const renderer = createCLIRenderer(rendererOptions);
+const cycle = createCycle({
+  memoryEngine: new InMemoryMemoryEngine(),
+  artifactStore: new InMemoryArtifactStore(),
+  observers: [renderer]
+});
+
+cycle.register("release-orchestration", ParentWorkflow);
+cycle.register("service-analysis", ChildWorkflow);
+
+const result = await cycle.run(
+  "release-orchestration",
+  createWorkflowInput({
+    product: "Cycle",
+    objective: "Validate the new sub workflow branch renderer in a release-ready scenario.",
+    services: ["api-gateway", "workflow-engine", "reporting-worker"],
+    environment: "staging"
+  })
+);
+
+if (isPersistentInkRenderer(rendererOptions)) {
+  process.stdin.resume();
+} else {
+  printResult(result);
+  renderer.close();
+}

--- a/sample-project/tsconfig.json
+++ b/sample-project/tsconfig.json
@@ -1,8 +1,13 @@
 {
   "compilerOptions": {
     "target": "ES2022",
+    "baseUrl": ".",
+    "ignoreDeprecations": "6.0",
     "module": "NodeNext",
     "moduleResolution": "NodeNext",
+    "paths": {
+      "agentic-task-kit": ["../dist/index.d.ts"]
+    },
     "strict": true,
     "noUncheckedIndexedAccess": true,
     "exactOptionalPropertyTypes": true,

--- a/src/artifacts.ts
+++ b/src/artifacts.ts
@@ -1,7 +1,8 @@
 import type {
   Artifact,
   ArtifactStore,
-  ExecutionEvent
+  ExecutionEvent,
+  RunArtifact
 } from "./types.js";
 import { ExecutionBroadcaster } from "./events.js";
 
@@ -62,6 +63,7 @@ type ObservedArtifactStoreArgs = {
   workflowId: string;
   runId: string;
   now: () => number;
+  onCreate?: (artifact: RunArtifact) => void | Promise<void>;
 };
 
 export function createObservedArtifactStore(args: ObservedArtifactStoreArgs): ArtifactStore {
@@ -88,6 +90,10 @@ export function createObservedArtifactStore(args: ObservedArtifactStoreArgs): Ar
   return {
     async create(input) {
       const artifact = await args.store.create(input);
+      await args.onCreate?.({
+        ...artifact,
+        bytes: new Uint8Array(input.bytes)
+      });
       await emit("artifact.created", `artifact created ${artifact.name}`, {
         artifactId: artifact.artifactId,
         name: artifact.name,

--- a/src/cycle.ts
+++ b/src/cycle.ts
@@ -3,6 +3,7 @@ import { randomUUID } from "node:crypto";
 import { createUnavailableAIProvider } from "./ai.js";
 import { createObservedArtifactStore, InMemoryArtifactStore } from "./artifacts.js";
 import { ExecutionBroadcaster } from "./events.js";
+import { createExecutionHistoryTracker } from "./history.js";
 import { createTaskLogger } from "./logging.js";
 import {
   createObservedMemoryEngine,
@@ -17,12 +18,17 @@ import type {
   AISessionMessage,
   ArtifactStore,
   Cycle,
+  CycleRunResult,
   CycleOptions,
   ExecutionFrame,
+  ExecutionHistoryTracker,
   ExecutionStatus,
+  LifecycleReport,
   MemoryRecordInput,
   ParallelTransition,
   RunOptions,
+  RunArtifact,
+  SubWorkflowRunOptions,
   TaskResult,
   Transition,
   WorkflowInput,
@@ -151,6 +157,72 @@ async function injectMemory(
   }
 }
 
+const EMPTY_LIFECYCLE_REPORT: LifecycleReport = {
+  archivedIds: [],
+  deletedIds: [],
+  compressedIds: [],
+  expiredIds: []
+};
+
+function isRunScopedRecord(
+  record: { workflowId?: string; runId?: string },
+  workflowId: string,
+  runId: string,
+): boolean {
+  return record.runId === runId || record.workflowId === workflowId;
+}
+
+function sortRecordsByTimestamp(left: { createdAt: number }, right: { createdAt: number }): number {
+  return left.createdAt - right.createdAt;
+}
+
+async function collectRunResultSnapshot(args: {
+  frame: ExecutionFrame;
+  memory: WorkflowContext["memory"];
+  artifacts: RunArtifact[];
+  lifecycle: LifecycleReport;
+  history: ExecutionHistoryTracker;
+}): Promise<CycleRunResult> {
+  const activeRecords = (await args.memory.list({ archived: false }))
+    .filter((record) => isRunScopedRecord(record, args.frame.workflowId, args.frame.runId))
+    .sort(sortRecordsByTimestamp);
+  const archivedRecords = (await args.memory.list({ archived: true }))
+    .filter((record) => isRunScopedRecord(record, args.frame.workflowId, args.frame.runId))
+    .sort(sortRecordsByTimestamp);
+
+  return {
+    frame: args.frame,
+    memory: {
+      records: [...activeRecords, ...archivedRecords],
+      activeRecords,
+      archivedRecords,
+      lifecycle: args.lifecycle
+    },
+    artifacts: {
+      artifacts: args.artifacts.map((artifact) => ({
+        ...artifact,
+        bytes: new Uint8Array(artifact.bytes)
+      }))
+    },
+    history: args.history.snapshot()
+  };
+}
+
+type ParentRunContext = {
+  workflowId: string;
+  runId: string;
+  branchId?: string;
+};
+
+type InternalRunOptions = {
+  key: string;
+  input: WorkflowInput;
+  options?: RunOptions | SubWorkflowRunOptions;
+  broadcaster?: ExecutionBroadcaster;
+  historyTracker: ExecutionHistoryTracker;
+  parent?: ParentRunContext;
+};
+
 class DefaultCycle implements Cycle {
   private readonly workflows = new Map<string, WorkflowDefinition>();
   private readonly aiProvider: AIProvider;
@@ -190,23 +262,126 @@ class DefaultCycle implements Cycle {
     key: string,
     input: WorkflowInput,
     options: RunOptions = {},
-  ): Promise<{ frame: ExecutionFrame }> {
-    const workflow = this.workflows.get(key);
-    if (!workflow) {
-      throw new Error(`Workflow "${key}" is not registered.`);
-    }
-
-    const observers = options.observers ?? [];
+  ): Promise<CycleRunResult> {
+    const historyTracker = createExecutionHistoryTracker();
     const runBroadcaster = new ExecutionBroadcaster([
       ...this.broadcaster.listObservers(),
-      ...observers
+      ...(options.observers ?? []),
+      historyTracker
     ]);
 
     await runBroadcaster.start();
+    let finalStatus: "success" | "fail" | undefined;
+
+    try {
+      const result = await this.runInternal({
+        key,
+        input,
+        options,
+        broadcaster: runBroadcaster,
+        historyTracker
+      });
+      finalStatus = result.frame.status === "success" ? "success" : "fail";
+      return result;
+    } finally {
+      await runBroadcaster.stop(finalStatus);
+    }
+  }
+
+  private async runSubWorkflow(
+    parent: ParentRunContext,
+    key: string,
+    input: WorkflowInput,
+    broadcaster: ExecutionBroadcaster,
+    options: SubWorkflowRunOptions = {},
+  ): Promise<CycleRunResult> {
+    const branchId = options.branchId ?? `branch_${randomUUID().slice(0, 8)}`;
+    const historyTracker = createExecutionHistoryTracker();
+    broadcaster.addObserver(historyTracker);
+
+    await broadcaster.emit({
+      type: "branch.started",
+      timestamp: this.now(),
+      workflowId: parent.workflowId,
+      runId: parent.runId,
+      branchId,
+      summary: options.summary ?? `sub-workflow ${key} started`,
+      meta: {
+        subWorkflowKey: key
+      }
+    });
+
+    const workflow = this.workflows.get(key);
+    if (!workflow) {
+      broadcaster.removeObserver(historyTracker);
+      throw new Error(`Workflow "${key}" is not registered.`);
+    }
+
+    try {
+      const result = await this.runInternal({
+        key,
+        input,
+        options,
+        broadcaster,
+        historyTracker,
+        parent: {
+          ...parent,
+          branchId
+        }
+      });
+
+      await broadcaster.emit({
+        type: "branch.completed",
+        timestamp: this.now(),
+        workflowId: parent.workflowId,
+        runId: parent.runId,
+        branchId,
+        summary: options.summary ?? `sub-workflow ${key} completed`,
+        status: result.frame.status,
+        meta: {
+          subWorkflowKey: key,
+          childWorkflowId: result.frame.workflowId,
+          childRunId: result.frame.runId
+        }
+      });
+
+      return result;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      await broadcaster.emit({
+        type: "branch.completed",
+        timestamp: this.now(),
+        workflowId: parent.workflowId,
+        runId: parent.runId,
+        branchId,
+        summary: options.summary ?? `sub-workflow ${key} failed`,
+        status: "fail",
+        meta: {
+          subWorkflowKey: key,
+          errorMessage: message
+        }
+      });
+      throw error;
+    } finally {
+      broadcaster.removeObserver(historyTracker);
+    }
+  }
+
+  private async runInternal(args: InternalRunOptions): Promise<CycleRunResult> {
+    const workflow = this.workflows.get(args.key);
+    if (!workflow) {
+      throw new Error(`Workflow "${args.key}" is not registered.`);
+    }
+
+    const runBroadcaster = args.broadcaster;
+    if (!runBroadcaster) {
+      throw new Error("Run broadcaster is required.");
+    }
 
     const workflowId = `${workflow.name}-${randomUUID().slice(0, 8)}`;
     const runId = `run_${randomUUID().slice(0, 8)}`;
     const frame = createFrame(workflowId, runId, workflow.start, this.now());
+    const runArtifacts: RunArtifact[] = [];
     const memory = createObservedMemoryEngine({
       engine: this.memoryEngine,
       broadcaster: runBroadcaster,
@@ -219,18 +394,32 @@ class DefaultCycle implements Cycle {
       broadcaster: runBroadcaster,
       workflowId,
       runId,
-      now: this.now
+      now: this.now,
+      onCreate: (artifact) => {
+        runArtifacts.push(artifact);
+      }
     });
+    let lifecycleReport = EMPTY_LIFECYCLE_REPORT;
 
-    await injectRag(workflowId, runId, memory, this.now(), options.rag);
-    await injectMemory(memory, options.memoryInjection);
+    const meta =
+      args.parent
+        ? {
+            parentWorkflowId: args.parent.workflowId,
+            parentRunId: args.parent.runId,
+            ...(args.parent.branchId ? { branchId: args.parent.branchId } : {})
+          }
+        : undefined;
+
+    await injectRag(workflowId, runId, memory, this.now(), args.options?.rag);
+    await injectMemory(memory, args.options?.memoryInjection);
 
     await runBroadcaster.emit({
       type: "workflow.started",
       timestamp: this.now(),
       workflowId,
       runId,
-      summary: `${workflow.name} start=${workflow.start}`
+      summary: `${workflow.name} start=${workflow.start}`,
+      ...(meta ? { meta } : {})
     });
 
     const endState = workflow.end ?? "end";
@@ -251,7 +440,8 @@ class DefaultCycle implements Cycle {
           workflowId,
           runId,
           taskName: task.name,
-          summary: `queued ${task.name}`
+          summary: `queued ${task.name}`,
+          ...(meta ? { meta } : {})
         });
 
         await runBroadcaster.emit({
@@ -260,7 +450,8 @@ class DefaultCycle implements Cycle {
           workflowId,
           runId,
           taskName: task.name,
-          summary: `started ${task.name}`
+          summary: `started ${task.name}`,
+          ...(meta ? { meta } : {})
         });
 
         const log = createTaskLogger({
@@ -268,6 +459,7 @@ class DefaultCycle implements Cycle {
           workflowId,
           runId,
           taskName: task.name,
+          ...(args.parent?.branchId ? { branchId: args.parent.branchId } : {}),
           now: this.now
         });
         const memoryContext = await memory.beforeStep({
@@ -277,21 +469,32 @@ class DefaultCycle implements Cycle {
           taskName: task.name,
           taskType: task.memoryTaskType,
           phase: task.memoryPhase,
-          input,
+          input: args.input,
           now: this.now()
         });
 
         const context: WorkflowContext = {
           workflowId,
           runId,
-          input,
+          input: args.input,
           session: createSession(this.llmModelId, this.embeddingModelId),
           ai: this.aiProvider,
           memory,
           memoryContext,
           artifacts,
           log,
-          now: this.now
+          now: this.now,
+          runSubWorkflow: (key, input, options) =>
+            this.runSubWorkflow(
+              {
+                workflowId,
+                runId
+              },
+              key,
+              input,
+              runBroadcaster,
+              options
+            )
         };
 
         if (task.before) {
@@ -322,7 +525,7 @@ class DefaultCycle implements Cycle {
           taskName: task.name,
           taskType: task.memoryTaskType,
           phase: task.memoryPhase,
-          input,
+          input: args.input,
           result,
           now: this.now()
         });
@@ -345,6 +548,7 @@ class DefaultCycle implements Cycle {
             summary: errorMessage,
             status: result.status,
             meta: {
+              ...meta,
               errorMessage,
               ...(result.error?.code ? { errorCode: result.error.code } : {}),
               ...(result.error?.details !== undefined
@@ -362,7 +566,8 @@ class DefaultCycle implements Cycle {
               runId,
               taskName: task.name,
               summary: `retry scheduled for ${task.name}`,
-              status: result.status
+              status: result.status,
+              ...(meta ? { meta } : {})
             });
           } else {
             await runBroadcaster.emit({
@@ -372,7 +577,8 @@ class DefaultCycle implements Cycle {
               runId,
               taskName: task.name,
               summary: `completed ${task.name}`,
-              status: result.status
+              status: result.status,
+              ...(meta ? { meta } : {})
             });
           }
         }
@@ -387,7 +593,7 @@ class DefaultCycle implements Cycle {
         }
       }
 
-      await memory.runLifecycle(this.now());
+      lifecycleReport = await memory.runLifecycle(this.now());
       frame.status = finalStatus;
 
       if (finalStatus === "fail") {
@@ -399,6 +605,7 @@ class DefaultCycle implements Cycle {
           summary: `${workflow.name} failed`,
           status: finalStatus,
           meta: {
+            ...meta,
             errors: [...frame.errors],
             errorMessage: frame.errors[frame.errors.length - 1]
           }
@@ -412,14 +619,20 @@ class DefaultCycle implements Cycle {
           summary: `${workflow.name} completed`,
           status: finalStatus,
           meta: {
+            ...meta,
             completedTasks: [...frame.completedTasks]
           }
         });
       }
 
       await runBroadcaster.flush();
-      await runBroadcaster.stop(finalStatus);
-      return { frame };
+      return collectRunResultSnapshot({
+        frame,
+        memory,
+        artifacts: runArtifacts,
+        lifecycle: lifecycleReport,
+        history: args.historyTracker
+      });
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       frame.status = "fail";
@@ -434,12 +647,18 @@ class DefaultCycle implements Cycle {
         summary: message,
         status: "fail",
         meta: {
+          ...meta,
           errorMessage: message
         }
       });
       await runBroadcaster.flush();
-      await runBroadcaster.stop("fail");
-      return { frame };
+      return collectRunResultSnapshot({
+        frame,
+        memory,
+        artifacts: runArtifacts,
+        lifecycle: lifecycleReport,
+        history: args.historyTracker
+      });
     }
   }
 }

--- a/src/events.ts
+++ b/src/events.ts
@@ -15,6 +15,10 @@ export class ExecutionBroadcaster {
     this.observers.add(observer);
   }
 
+  removeObserver(observer: ExecutionObserver): void {
+    this.observers.delete(observer);
+  }
+
   listObservers(): ExecutionObserver[] {
     return [...this.observers];
   }

--- a/src/history.ts
+++ b/src/history.ts
@@ -1,0 +1,60 @@
+import type {
+  ExecutionEvent,
+  ExecutionHistorySnapshot,
+  ExecutionHistoryTracker,
+  TaskLogEvent
+} from "./types.js";
+
+class InMemoryExecutionHistoryTracker implements ExecutionHistoryTracker {
+  private readonly events: ExecutionEvent[] = [];
+  private readonly taskLogs: TaskLogEvent[] = [];
+  private readonly listeners = new Set<(snapshot: ExecutionHistorySnapshot) => void>();
+  private updatedAt: number | undefined;
+
+  onEvent(event: ExecutionEvent): void {
+    this.events.push(event);
+    this.updatedAt = event.timestamp;
+    this.notify();
+  }
+
+  onTaskLog(event: TaskLogEvent): void {
+    this.taskLogs.push(event);
+    this.updatedAt = event.timestamp;
+    this.notify();
+  }
+
+  snapshot(): ExecutionHistorySnapshot {
+    return {
+      events: [...this.events],
+      taskLogs: [...this.taskLogs],
+      ...(this.updatedAt !== undefined ? { updatedAt: this.updatedAt } : {})
+    };
+  }
+
+  subscribe(listener: (snapshot: ExecutionHistorySnapshot) => void): () => void {
+    this.listeners.add(listener);
+    listener(this.snapshot());
+
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  reset(): void {
+    this.events.length = 0;
+    this.taskLogs.length = 0;
+    this.updatedAt = undefined;
+    this.notify();
+  }
+
+  private notify(): void {
+    const snapshot = this.snapshot();
+    for (const listener of this.listeners) {
+      listener(snapshot);
+    }
+  }
+}
+
+export function createExecutionHistoryTracker(): ExecutionHistoryTracker {
+  return new InMemoryExecutionHistoryTracker();
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { createCycle } from "./cycle.js";
 export { createUnavailableAIProvider } from "./ai.js";
 export { AIProviderRequestError } from "./errors.js";
 export { ExecutionBroadcaster } from "./events.js";
+export { createExecutionHistoryTracker } from "./history.js";
 export { createTaskLogger } from "./logging.js";
 export {
   createObservedMemoryEngine,
@@ -57,10 +58,15 @@ export type {
   CLIRenderer,
   CLIRendererOptions,
   Cycle,
+  CycleRunArtifactSnapshot,
+  CycleRunMemorySnapshot,
+  CycleRunResult,
   CycleOptions,
   EmbeddingProvider,
   ExecutionEvent,
   ExecutionFrame,
+  ExecutionHistorySnapshot,
+  ExecutionHistoryTracker,
   ExecutionObserver,
   ExecutionStatus,
   GraphStore,
@@ -94,7 +100,9 @@ export type {
   OpenAIChatProviderFileConfig,
   OpenAIChatProviderConfigFileOptions,
   ParallelTransition,
+  RunArtifact,
   RunOptions,
+  SubWorkflowRunOptions,
   TaskLike,
   TaskLogEvent,
   TaskLogLevel,

--- a/src/ink-renderer.tsx
+++ b/src/ink-renderer.tsx
@@ -5,12 +5,16 @@ import { useEffect, useState, type ReactElement } from "react";
 
 import {
   createInitialRendererState,
+  formatDuration,
+  getTaskDurationMs,
   levelWeight,
   pushDebugLogLine,
   pushTaskLog,
   reduceExecutionEvent,
   truncateText,
-  type RendererState
+  type RendererState,
+  type WorkflowRenderState,
+  type WorkflowTaskState
 } from "./renderer-model.js";
 import type {
   CLIRenderer,
@@ -51,18 +55,19 @@ type InkRendererScreenProps = {
 
 const DEFAULT_COLUMNS = 100;
 const DEFAULT_ROWS = 24;
-const LEFT_MIN_WIDTH = 32;
-const RIGHT_MIN_WIDTH = 48;
+const LEFT_MIN_WIDTH = 36;
+const RIGHT_MIN_WIDTH = 42;
 const HISTORY_BUFFER_SIZE = 240;
 const TIMELINE_BUFFER_SIZE = 480;
+const TASK_BOX_INNER_WIDTH = 16;
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
 }
 
-function computeColumns(columns: number): { leftWidth: number; rightWidth: number } {
+function computeBottomColumns(columns: number): { leftWidth: number; rightWidth: number } {
   const total = Math.max(columns, LEFT_MIN_WIDTH + RIGHT_MIN_WIDTH + 1);
-  const leftWidth = clamp(Math.floor(total * 0.4), LEFT_MIN_WIDTH, total - RIGHT_MIN_WIDTH - 1);
+  const leftWidth = clamp(Math.floor(total * 0.48), LEFT_MIN_WIDTH, total - RIGHT_MIN_WIDTH - 1);
   const rightWidth = total - leftWidth - 1;
   return {
     leftWidth,
@@ -75,30 +80,20 @@ function padLine(value: string, width: number): string {
   return clipped.length >= width ? clipped : clipped.padEnd(width, " ");
 }
 
-function buildSummaryLines(state: RendererState): string[] {
-  return [
-    `Workflow ${state.workflowId ?? "-"}`,
-    `Run      ${state.runId ?? "-"}`,
-    `Status   ${state.status ?? "running"}`,
-    `Current  ${state.currentTask ?? "-"}`,
-    `Active   ${[...state.activeTasks].join(", ") || "-"}`,
-    `Counts   art=${state.artifactCount} mem=${state.memoryWrites} retry=${state.retryCount} err=${state.errorCount}`,
-    `Failure  ${state.lastFailure ?? "-"}`
-  ];
-}
-
-function buildHeaderLine(state: RendererState, columns: number, focusedPane: InkPane): string {
-  const text = `Cycle Ink  workflow=${state.workflowId ?? "-"}  status=${state.status ?? "running"}  focus=${focusedPane}`;
+function buildHeaderLine(state: RendererState, columns: number): string {
+  const text =
+    `Cycle Ink  workflow=${state.workflowId ?? "-"}  status=${state.status ?? "running"}  current=${state.currentTask ?? "-"}  ` +
+    `art=${state.artifactCount} mem=${state.memoryWrites} retry=${state.retryCount} err=${state.errorCount}`;
   return padLine(text, columns);
 }
 
 function buildFooterLine(columns: number, focusedPane: InkPane, rightAutoFollow: boolean): string {
   const text =
-    `Tab pane  ↑↓/jk scroll  PgUp/PgDn page  Home/End,g/G edge  focus=${focusedPane}  follow=${rightAutoFollow ? "on" : "off"}`;
+    `Tab pane  up/down,j/k scroll  PgUp/PgDn page  Home/End,g/G edge  focus=${focusedPane}  follow=${rightAutoFollow ? "on" : "off"}`;
   return padLine(text, columns);
 }
 
-function withTitle(title: string, width: number, focused: boolean): string {
+function withTitle(title: string, width: number, focused = false): string {
   return padLine(`${focused ? ">" : " "} ${title}`, width);
 }
 
@@ -112,6 +107,197 @@ function visibleWindow(lines: string[], start: number, size: number): string[] {
 
 function maxScroll(lineCount: number, viewportSize: number): number {
   return Math.max(0, lineCount - viewportSize);
+}
+
+function taskStatusLabel(task: WorkflowTaskState): string {
+  switch (task.status) {
+    case "queued":
+      return "QUE";
+    case "running":
+      return "RUN";
+    case "completed":
+      return "DONE";
+    case "failed":
+      return "FAIL";
+    case "retry":
+      return "RETRY";
+  }
+}
+
+function workflowStatusLabel(status: WorkflowRenderState["status"]): string {
+  switch (status) {
+    case "success":
+      return "SUCCESS";
+    case "fail":
+      return "FAIL";
+    default:
+      return "RUNNING";
+  }
+}
+
+function buildTaskBox(task: WorkflowTaskState, now: number): string[] {
+  const duration = formatDuration(getTaskDurationMs(task, now));
+  const top = `┌${"─".repeat(TASK_BOX_INNER_WIDTH)}┐`;
+  const name = `│${padLine(task.taskName, TASK_BOX_INNER_WIDTH)}│`;
+  const detail = `│${padLine(`${taskStatusLabel(task)} ${duration}`, TASK_BOX_INNER_WIDTH)}│`;
+  const bottom = `└${"─".repeat(TASK_BOX_INNER_WIDTH)}┘`;
+  return [top, name, detail, bottom];
+}
+
+function groupTasksForWidth(
+  tasks: WorkflowTaskState[],
+  width: number,
+  indent: number
+): WorkflowTaskState[][] {
+  const groups: WorkflowTaskState[][] = [];
+  const boxWidth = TASK_BOX_INNER_WIDTH + 2;
+  const gapWidth = 3;
+  const availableWidth = Math.max(boxWidth, width - indent);
+  let current: WorkflowTaskState[] = [];
+  let consumed = 0;
+
+  for (const task of tasks) {
+    const nextWidth = current.length === 0 ? boxWidth : boxWidth + gapWidth;
+    if (current.length > 0 && consumed + nextWidth > availableWidth) {
+      groups.push(current);
+      current = [task];
+      consumed = boxWidth;
+      continue;
+    }
+
+    current.push(task);
+    consumed += nextWidth;
+  }
+
+  if (current.length > 0) {
+    groups.push(current);
+  }
+
+  return groups;
+}
+
+function renderTaskGroups(
+  tasks: WorkflowTaskState[],
+  width: number,
+  indent: number,
+  now: number
+): string[] {
+  if (tasks.length === 0) {
+    const idleTask: WorkflowTaskState = {
+      taskName: "waiting",
+      status: "queued",
+      updatedAt: now
+    };
+    tasks = [idleTask];
+  }
+
+  const groups = groupTasksForWidth(tasks, width, indent);
+  const lines: string[] = [];
+  const prefix = " ".repeat(indent);
+  const connector = ["   ", "   ", "──▶", "   "];
+
+  for (const group of groups) {
+    const rendered = group.map((task) => buildTaskBox(task, now));
+    for (let row = 0; row < 4; row += 1) {
+      let line = prefix;
+      for (let index = 0; index < rendered.length; index += 1) {
+        line += rendered[index]?.[row] ?? "";
+        if (index < rendered.length - 1) {
+          line += connector[row] ?? "   ";
+        }
+      }
+      lines.push(padLine(line, width));
+    }
+  }
+
+  return lines;
+}
+
+function workflowDurationMs(workflow: WorkflowRenderState, now: number): number | undefined {
+  if (workflow.startedAt === undefined) {
+    return undefined;
+  }
+
+  const endedAt = workflow.completedAt ?? workflow.updatedAt ?? now;
+  return Math.max(0, endedAt - workflow.startedAt);
+}
+
+function renderWorkflowBranchLines(
+  state: RendererState,
+  workflowId: string,
+  width: number,
+  depth: number,
+  branchLabel?: string
+): string[] {
+  const workflow = state.workflows.get(workflowId);
+  if (!workflow) {
+    return [];
+  }
+
+  const now = state.updatedAt ?? Date.now();
+  const indent = depth * 4;
+  const lines: string[] = [];
+  const headerPrefix = " ".repeat(indent);
+  const workflowLabel =
+    `${workflow.name} [${workflowStatusLabel(workflow.status)} ${formatDuration(workflowDurationMs(workflow, now))}]`;
+
+  if (branchLabel) {
+    lines.push(padLine(`${headerPrefix}${branchLabel}`, width));
+  }
+
+  lines.push(padLine(`${headerPrefix}${workflowLabel}`, width));
+
+  const orderedTasks = workflow.taskOrder
+    .map((taskName) => workflow.tasks.get(taskName))
+    .filter((task): task is WorkflowTaskState => task !== undefined);
+  lines.push(...renderTaskGroups(orderedTasks, width, indent, now));
+
+  for (const branchId of workflow.branchOrder) {
+    const branch = workflow.branches.get(branchId);
+    if (!branch) {
+      continue;
+    }
+
+    const branchSummary = `${headerPrefix}└─ ${branch.branchId} [${branch.status.toUpperCase()}] ${branch.summary}`;
+    if (branch.childWorkflowId) {
+      lines.push(
+        ...renderWorkflowBranchLines(
+          state,
+          branch.childWorkflowId,
+          width,
+          depth + 1,
+          branchSummary
+        )
+      );
+    } else {
+      lines.push(padLine(branchSummary, width));
+      lines.push(padLine(`${" ".repeat((depth + 1) * 4)}(sub workflow pending)`, width));
+    }
+  }
+
+  return lines;
+}
+
+function buildFlowchartLines(state: RendererState, width: number): string[] {
+  const rootWorkflowIds = state.workflowOrder.filter((workflowId) => {
+    const workflow = state.workflows.get(workflowId);
+    return workflow && !workflow.parentWorkflowId;
+  });
+
+  if (rootWorkflowIds.length === 0 && state.workflowId) {
+    rootWorkflowIds.push(state.workflowId);
+  }
+
+  if (rootWorkflowIds.length === 0) {
+    return [padLine("workflow events are waiting...", width)];
+  }
+
+  const lines: string[] = [];
+  for (const workflowId of rootWorkflowIds) {
+    lines.push(...renderWorkflowBranchLines(state, workflowId, width, 0));
+  }
+
+  return lines;
 }
 
 export function reduceInkUIState(
@@ -149,7 +335,9 @@ export function reduceInkUIState(
       return next;
     case "sync":
       next.leftScroll = clamp(next.leftScroll, 0, action.leftMaxScroll);
-      next.rightScroll = next.rightAutoFollow ? action.rightMaxScroll : clamp(next.rightScroll, 0, action.rightMaxScroll);
+      next.rightScroll = next.rightAutoFollow
+        ? action.rightMaxScroll
+        : clamp(next.rightScroll, 0, action.rightMaxScroll);
       next.rightAutoFollow = next.rightScroll >= action.rightMaxScroll;
       return next;
   }
@@ -168,27 +356,32 @@ export function InkRendererScreen({
     rightAutoFollow: true
   });
 
-  const { leftWidth, rightWidth } = computeColumns(columns);
-  const usableRows = Math.max(rows, 12);
-  const bodyHeight = Math.max(usableRows - 2, 8);
-  const leftSummaryLines = buildSummaryLines(state).map((line) => padLine(line, leftWidth));
-  const leftHistoryViewport = Math.max(bodyHeight - leftSummaryLines.length - 1, 1);
-  const rightViewport = Math.max(bodyHeight - 1, 1);
-  const leftHistoryLines = state.taskHistory.map((row) => padLine(row.text, leftWidth));
+  const { leftWidth, rightWidth } = computeBottomColumns(columns);
+  const usableRows = Math.max(rows, 16);
+  const footerRows = finalStatus ? 3 : 2;
+  const contentRows = Math.max(usableRows - footerRows, 10);
+  const flowchartLines = buildFlowchartLines(state, columns);
+  const flowchartViewport = clamp(flowchartLines.length, 6, Math.max(6, contentRows - 6));
+  const bottomViewport = Math.max(4, contentRows - flowchartViewport - 2);
+  const leftLines = state.taskHistory.map((row) => padLine(row.text, leftWidth));
   const rightLines = state.timeline.map((row) => padLine(row.text, rightWidth));
   const metrics = {
-    leftMaxScroll: maxScroll(leftHistoryLines.length, leftHistoryViewport),
-    rightMaxScroll: maxScroll(rightLines.length, rightViewport),
-    pageSize: Math.max(1, Math.min(leftHistoryViewport, rightViewport) - 1)
+    leftMaxScroll: maxScroll(leftLines.length, bottomViewport),
+    rightMaxScroll: maxScroll(rightLines.length, bottomViewport),
+    pageSize: Math.max(1, bottomViewport - 1)
   };
 
   useEffect(() => {
     setUiState((current) =>
-      reduceInkUIState(current, {
-        type: "sync",
-        leftMaxScroll: metrics.leftMaxScroll,
-        rightMaxScroll: metrics.rightMaxScroll
-      }, metrics)
+      reduceInkUIState(
+        current,
+        {
+          type: "sync",
+          leftMaxScroll: metrics.leftMaxScroll,
+          rightMaxScroll: metrics.rightMaxScroll
+        },
+        metrics
+      )
     );
   }, [metrics.leftMaxScroll, metrics.rightMaxScroll, metrics.pageSize]);
 
@@ -228,37 +421,41 @@ export function InkRendererScreen({
     }
   });
 
-  const leftPanelLines = [
-    withTitle(`Workflow + History (${state.taskHistory.length})`, leftWidth, uiState.focusedPane === "left"),
-    ...leftSummaryLines,
-    ...visibleWindow(leftHistoryLines, uiState.leftScroll, leftHistoryViewport)
+  const topPanelLines = [
+    withTitle("워크플로우 파이프라인 플로우차트", columns),
+    ...visibleWindow(flowchartLines, 0, flowchartViewport)
   ];
-  while (leftPanelLines.length < bodyHeight) {
-    leftPanelLines.push(" ".repeat(leftWidth));
+  while (topPanelLines.length < flowchartViewport + 1) {
+    topPanelLines.push(" ".repeat(columns));
   }
 
-  const rightPanelLines = [
-    withTitle(
-      `Logs (${state.timeline.length}) follow=${uiState.rightAutoFollow ? "on" : "off"}`,
-      rightWidth,
-      uiState.focusedPane === "right"
-    ),
-    ...visibleWindow(rightLines, uiState.rightScroll, rightViewport)
-  ];
-  while (rightPanelLines.length < bodyHeight) {
+  const bottomTitleLine =
+    `${withTitle("워크플로우 task 실행 이력", leftWidth, uiState.focusedPane === "left")}│` +
+    `${withTitle(`실행 로그 (${state.timeline.length})`, rightWidth, uiState.focusedPane === "right")}`;
+
+  const leftPanelLines = visibleWindow(leftLines, uiState.leftScroll, bottomViewport);
+  const rightPanelLines = visibleWindow(rightLines, uiState.rightScroll, bottomViewport);
+  while (leftPanelLines.length < bottomViewport) {
+    leftPanelLines.push(" ".repeat(leftWidth));
+  }
+  while (rightPanelLines.length < bottomViewport) {
     rightPanelLines.push(" ".repeat(rightWidth));
   }
 
-  const mergedBodyLines: string[] = [];
-  for (let index = 0; index < bodyHeight; index += 1) {
-    mergedBodyLines.push(`${leftPanelLines[index] ?? " ".repeat(leftWidth)}│${rightPanelLines[index] ?? " ".repeat(rightWidth)}`);
+  const mergedBottomLines: string[] = [];
+  for (let index = 0; index < bottomViewport; index += 1) {
+    mergedBottomLines.push(`${leftPanelLines[index] ?? " ".repeat(leftWidth)}│${rightPanelLines[index] ?? " ".repeat(rightWidth)}`);
   }
 
   return (
     <>
-      <Text>{buildHeaderLine(state, columns, uiState.focusedPane)}</Text>
-      {mergedBodyLines.map((line, index) => (
-        <Text key={`body-${index}`}>{line}</Text>
+      <Text>{buildHeaderLine(state, columns)}</Text>
+      {topPanelLines.map((line, index) => (
+        <Text key={`top-${index}`}>{line}</Text>
+      ))}
+      <Text>{bottomTitleLine}</Text>
+      {mergedBottomLines.map((line, index) => (
+        <Text key={`bottom-${index}`}>{line}</Text>
       ))}
       <Text>{buildFooterLine(columns, uiState.focusedPane, uiState.rightAutoFollow)}</Text>
       {finalStatus ? <Text>{padLine(`Final status: ${finalStatus}`, columns)}</Text> : null}
@@ -267,7 +464,7 @@ export function InkRendererScreen({
 }
 
 type InkRendererResolvedOptions = Required<
-  Pick<CLIRendererOptions, "enabled" | "refreshMs" | "maxRecentEvents" | "maxRecentLogs"> &
+  Pick<CLIRendererOptions, "enabled" | "refreshMs" | "maxRecentEvents" | "maxRecentLogs" | "persistAfterCompletion"> &
     Pick<CLIRendererOptions, "mode" | "logLevel">
 > & {
   stream: NodeJS.WriteStream;
@@ -287,6 +484,13 @@ export class InkCLIRenderer implements CLIRenderer {
   private inkInstance: ReturnType<typeof render> | null = null;
   private debugLineReader: ReadLineInterface | null = null;
   private resizeHandler: (() => void) | null = null;
+  private readonly processSignalHandler = (): void => {
+    this.shutdown({
+      writeSummary: false,
+      exitProcess: true,
+      exitCode: 0
+    });
+  };
 
   constructor(options: CLIRendererOptions = {}) {
     this.options = {
@@ -295,6 +499,7 @@ export class InkCLIRenderer implements CLIRenderer {
       refreshMs: options.refreshMs ?? 100,
       maxRecentEvents: Math.max(options.maxRecentEvents ?? 5, 8),
       maxRecentLogs: Math.max(options.maxRecentLogs ?? 5, 8),
+      persistAfterCompletion: options.persistAfterCompletion ?? true,
       logLevel: options.logLevel ?? "info",
       stream: options.stream ?? process.stdout,
       errorStream: options.errorStream ?? process.stderr,
@@ -320,6 +525,7 @@ export class InkCLIRenderer implements CLIRenderer {
     this.enterAlternateScreen();
     this.attachResizeHandler();
     this.attachDebugStream();
+    this.attachProcessSignalHandlers();
     this.renderNow();
   }
 
@@ -329,6 +535,33 @@ export class InkCLIRenderer implements CLIRenderer {
     }
 
     this.finalStatus.value = finalStatus;
+    this.renderNow();
+
+    if (this.options.persistAfterCompletion) {
+      return;
+    }
+
+    this.close();
+  }
+
+  close(): void {
+    this.shutdown({
+      writeSummary: true
+    });
+  }
+
+  private shutdown(args: {
+    writeSummary: boolean;
+    exitProcess?: boolean;
+    exitCode?: number;
+  }): void {
+    if (!this.started) {
+      if (args.exitProcess) {
+        process.exit(args.exitCode ?? 0);
+      }
+      return;
+    }
+
     if (this.pendingRender) {
       clearTimeout(this.pendingRender);
       this.pendingRender = null;
@@ -342,11 +575,19 @@ export class InkCLIRenderer implements CLIRenderer {
       this.resizeHandler = null;
     }
 
+    this.detachProcessSignalHandlers();
     this.inkInstance?.unmount();
     this.inkInstance = null;
     this.leaveAlternateScreen();
-    this.writeFinalSummary();
     this.started = false;
+
+    if (args.writeSummary) {
+      this.writeFinalSummary();
+    }
+
+    if (args.exitProcess) {
+      process.exit(args.exitCode ?? 0);
+    }
   }
 
   resize(width: number, height: number): void {
@@ -357,6 +598,9 @@ export class InkCLIRenderer implements CLIRenderer {
 
   onEvent(event: ExecutionEvent): void {
     this.start();
+    if (event.type === "workflow.started") {
+      this.finalStatus.value = undefined;
+    }
     reduceExecutionEvent(
       this.state,
       event,
@@ -455,9 +699,19 @@ export class InkCLIRenderer implements CLIRenderer {
       stdout: this.options.stream,
       stderr: this.options.errorStream,
       stdin: process.stdin,
-      exitOnCtrlC: true,
+      exitOnCtrlC: false,
       patchConsole: true
     });
+  }
+
+  private attachProcessSignalHandlers(): void {
+    process.on("SIGINT", this.processSignalHandler);
+    process.on("SIGTERM", this.processSignalHandler);
+  }
+
+  private detachProcessSignalHandlers(): void {
+    process.off("SIGINT", this.processSignalHandler);
+    process.off("SIGTERM", this.processSignalHandler);
   }
 
   private enterAlternateScreen(): void {

--- a/src/renderer-model.ts
+++ b/src/renderer-model.ts
@@ -24,6 +24,45 @@ export type TimelineRow = {
   taskName?: string;
 };
 
+export type WorkflowTaskPhase = "queued" | "running" | "completed" | "failed" | "retry";
+
+export type WorkflowTaskState = {
+  taskName: string;
+  status: WorkflowTaskPhase;
+  queuedAt?: number;
+  startedAt?: number;
+  endedAt?: number;
+  updatedAt: number;
+};
+
+export type WorkflowBranchState = {
+  branchId: string;
+  summary: string;
+  status: "running" | "success" | "fail";
+  startedAt: number;
+  completedAt?: number;
+  childWorkflowId?: string;
+  childRunId?: string;
+};
+
+export type WorkflowRenderState = {
+  workflowId: string;
+  runId: string;
+  name: string;
+  summary: string;
+  status: "running" | "success" | "fail";
+  startedAt?: number;
+  updatedAt?: number;
+  completedAt?: number;
+  parentWorkflowId?: string;
+  parentRunId?: string;
+  branchId?: string;
+  taskOrder: string[];
+  tasks: Map<string, WorkflowTaskState>;
+  branchOrder: string[];
+  branches: Map<string, WorkflowBranchState>;
+};
+
 export type RendererState = {
   workflowId: string | undefined;
   runId: string | undefined;
@@ -42,6 +81,8 @@ export type RendererState = {
   errorCount: number;
   startedAt: number | undefined;
   updatedAt: number | undefined;
+  workflowOrder: string[];
+  workflows: Map<string, WorkflowRenderState>;
 };
 
 export function createInitialRendererState(): RendererState {
@@ -62,7 +103,9 @@ export function createInitialRendererState(): RendererState {
     retryCount: 0,
     errorCount: 0,
     startedAt: undefined,
-    updatedAt: undefined
+    updatedAt: undefined,
+    workflowOrder: [],
+    workflows: new Map()
   };
 }
 
@@ -85,6 +128,28 @@ export function formatClock(timestamp: number): string {
   return new Date(timestamp).toISOString().slice(11, 19);
 }
 
+export function formatDuration(durationMs: number | undefined): string {
+  if (durationMs === undefined || durationMs < 0) {
+    return "-";
+  }
+
+  if (durationMs < 1_000) {
+    return `${durationMs}ms`;
+  }
+
+  if (durationMs < 10_000) {
+    return `${(durationMs / 1_000).toFixed(1)}s`;
+  }
+
+  if (durationMs < 60_000) {
+    return `${Math.round(durationMs / 1_000)}s`;
+  }
+
+  const minutes = Math.floor(durationMs / 60_000);
+  const seconds = Math.round((durationMs % 60_000) / 1_000);
+  return `${minutes}m ${String(seconds).padStart(2, "0")}s`;
+}
+
 function firstErrorFromMeta(meta: Record<string, unknown> | undefined): string | undefined {
   const errors = meta?.errors;
   if (!Array.isArray(errors)) {
@@ -93,6 +158,192 @@ function firstErrorFromMeta(meta: Record<string, unknown> | undefined): string |
 
   const first = errors.find((error) => typeof error === "string");
   return typeof first === "string" ? first : undefined;
+}
+
+function getMetaString(
+  event: ExecutionEvent,
+  key: string
+): string | undefined {
+  const value = event.meta?.[key];
+  return typeof value === "string" ? value : undefined;
+}
+
+function extractParentInfo(event: ExecutionEvent): {
+  parentWorkflowId?: string;
+  parentRunId?: string;
+  branchId?: string;
+} {
+  const parentWorkflowId = getMetaString(event, "parentWorkflowId");
+  const parentRunId = getMetaString(event, "parentRunId");
+  const branchId = getMetaString(event, "branchId");
+
+  return {
+    ...(parentWorkflowId ? { parentWorkflowId } : {}),
+    ...(parentRunId ? { parentRunId } : {}),
+    ...(branchId ? { branchId } : {})
+  };
+}
+
+function simplifyWorkflowId(workflowId: string): string {
+  return workflowId.replace(/-[a-f0-9]{8}$/iu, "");
+}
+
+function inferWorkflowName(summary: string, workflowId: string): string {
+  if (summary.includes(" start=")) {
+    return summary.split(" start=")[0] ?? simplifyWorkflowId(workflowId);
+  }
+
+  if (summary.endsWith(" completed")) {
+    return summary.slice(0, -" completed".length);
+  }
+
+  if (summary.endsWith(" failed")) {
+    return summary.slice(0, -" failed".length);
+  }
+
+  return simplifyWorkflowId(workflowId);
+}
+
+function ensureWorkflowNode(
+  state: RendererState,
+  args: {
+    workflowId: string;
+    runId: string;
+    summary?: string;
+    parentWorkflowId?: string;
+    parentRunId?: string;
+    branchId?: string;
+  }
+): WorkflowRenderState {
+  const existing = state.workflows.get(args.workflowId);
+  if (existing) {
+    if (args.summary) {
+      existing.summary = args.summary;
+      existing.name = inferWorkflowName(args.summary, existing.workflowId);
+    }
+    if (args.parentWorkflowId) {
+      existing.parentWorkflowId = args.parentWorkflowId;
+    }
+    if (args.parentRunId) {
+      existing.parentRunId = args.parentRunId;
+    }
+    if (args.branchId) {
+      existing.branchId = args.branchId;
+    }
+    return existing;
+  }
+
+  const created: WorkflowRenderState = {
+    workflowId: args.workflowId,
+    runId: args.runId,
+    name: inferWorkflowName(args.summary ?? args.workflowId, args.workflowId),
+    summary: args.summary ?? "",
+    status: "running",
+    ...(args.parentWorkflowId ? { parentWorkflowId: args.parentWorkflowId } : {}),
+    ...(args.parentRunId ? { parentRunId: args.parentRunId } : {}),
+    ...(args.branchId ? { branchId: args.branchId } : {}),
+    taskOrder: [],
+    tasks: new Map(),
+    branchOrder: [],
+    branches: new Map()
+  };
+
+  state.workflows.set(args.workflowId, created);
+  if (!args.parentWorkflowId && !state.workflowOrder.includes(args.workflowId)) {
+    state.workflowOrder.push(args.workflowId);
+  }
+
+  return created;
+}
+
+function ensureBranch(
+  workflow: WorkflowRenderState,
+  branchId: string,
+  summary: string,
+  timestamp: number
+): WorkflowBranchState {
+  const existing = workflow.branches.get(branchId);
+  if (existing) {
+    existing.summary = summary || existing.summary;
+    return existing;
+  }
+
+  const created: WorkflowBranchState = {
+    branchId,
+    summary,
+    status: "running",
+    startedAt: timestamp
+  };
+  workflow.branches.set(branchId, created);
+  workflow.branchOrder.push(branchId);
+  return created;
+}
+
+function ensureTask(
+  workflow: WorkflowRenderState,
+  taskName: string,
+  timestamp: number
+): WorkflowTaskState {
+  const existing = workflow.tasks.get(taskName);
+  if (existing) {
+    existing.updatedAt = timestamp;
+    return existing;
+  }
+
+  const created: WorkflowTaskState = {
+    taskName,
+    status: "queued",
+    updatedAt: timestamp
+  };
+  workflow.tasks.set(taskName, created);
+  workflow.taskOrder.push(taskName);
+  return created;
+}
+
+function connectToParentWorkflow(
+  state: RendererState,
+  workflow: WorkflowRenderState,
+  event: ExecutionEvent
+): void {
+  const parentInfo = extractParentInfo(event);
+  if (!parentInfo.parentWorkflowId) {
+    return;
+  }
+
+  workflow.parentWorkflowId = parentInfo.parentWorkflowId;
+  if (parentInfo.parentRunId) {
+    workflow.parentRunId = parentInfo.parentRunId;
+  }
+  if (parentInfo.branchId) {
+    workflow.branchId = parentInfo.branchId;
+  }
+
+  const parent = ensureWorkflowNode(state, {
+    workflowId: parentInfo.parentWorkflowId,
+    runId: parentInfo.parentRunId ?? workflow.runId
+  });
+  if (parentInfo.branchId) {
+    const branch = ensureBranch(
+      parent,
+      parentInfo.branchId,
+      parentInfo.branchId,
+      event.timestamp
+    );
+    branch.childWorkflowId = workflow.workflowId;
+    branch.childRunId = workflow.runId;
+  }
+}
+
+export function getTaskDurationMs(
+  task: WorkflowTaskState,
+  now: number
+): number | undefined {
+  if (task.startedAt === undefined) {
+    return undefined;
+  }
+
+  const endedAt = task.endedAt ?? task.updatedAt ?? now;
+  return Math.max(0, endedAt - task.startedAt);
 }
 
 export function failureReasonForEvent(event: ExecutionEvent): string | undefined {
@@ -183,7 +434,10 @@ function clipMiddle(value: string, maxWidth: number): string {
   return `${value.slice(0, maxWidth - 3)}...`;
 }
 
-function buildTaskHistoryText(event: ExecutionEvent & { taskName: string }): string {
+function buildTaskHistoryText(
+  event: ExecutionEvent & { taskName: string },
+  durationMs?: number
+): string {
   const failureReason = failureReasonForEvent(event);
   const phase =
     event.type === "task.retry_scheduled"
@@ -197,13 +451,18 @@ function buildTaskHistoryText(event: ExecutionEvent & { taskName: string }): str
             : "FAIL";
 
   const detail = failureReason ?? event.summary;
-  return `${formatClock(event.timestamp)} ${clipMiddle(event.taskName, 18)} ${phase} ${detail}`;
+  const durationSuffix =
+    durationMs !== undefined && event.type !== "task.queued"
+      ? ` ${formatDuration(durationMs)}`
+      : "";
+  return `${formatClock(event.timestamp)} ${clipMiddle(event.taskName, 18)} ${phase}${durationSuffix} ${detail}`;
 }
 
 function pushTaskHistory(
   state: RendererState,
   event: ExecutionEvent & { taskName: string },
-  maxHistoryRows: number
+  maxHistoryRows: number,
+  durationMs?: number
 ): void {
   const phase =
     event.type === "task.retry_scheduled"
@@ -217,14 +476,75 @@ function pushTaskHistory(
             : "failed";
 
   state.taskHistory.push({
-    id: `${event.type}:${event.taskName}:${event.timestamp}`,
+    id: `${event.type}:${event.workflowId}:${event.taskName}:${event.timestamp}`,
     timestamp: event.timestamp,
     taskName: event.taskName,
     phase,
     summary: failureReasonForEvent(event) ?? event.summary,
-    text: buildTaskHistoryText(event)
+    text: buildTaskHistoryText(event, durationMs)
   });
   state.taskHistory = state.taskHistory.slice(-maxHistoryRows);
+}
+
+function updateTaskStateFromEvent(
+  state: RendererState,
+  event: Extract<ExecutionEvent, { taskName: string }>
+): WorkflowTaskState {
+  const workflow = ensureWorkflowNode(state, {
+    workflowId: event.workflowId,
+    runId: event.runId
+  });
+  connectToParentWorkflow(state, workflow, event);
+  const task = ensureTask(workflow, event.taskName, event.timestamp);
+
+  switch (event.type) {
+    case "task.queued":
+      task.status = "queued";
+      task.queuedAt ??= event.timestamp;
+      break;
+    case "task.started":
+      task.status = "running";
+      task.startedAt ??= event.timestamp;
+      break;
+    case "task.completed":
+      task.status = "completed";
+      task.startedAt ??= task.queuedAt ?? event.timestamp;
+      task.endedAt = event.timestamp;
+      break;
+    case "task.failed":
+      task.status = "failed";
+      task.startedAt ??= task.queuedAt ?? event.timestamp;
+      task.endedAt = event.timestamp;
+      break;
+    case "task.retry_scheduled":
+      task.status = "retry";
+      task.startedAt ??= task.queuedAt ?? event.timestamp;
+      task.endedAt = event.timestamp;
+      break;
+  }
+
+  task.updatedAt = event.timestamp;
+  workflow.updatedAt = event.timestamp;
+  return task;
+}
+
+function maybeSetRootWorkflow(state: RendererState, event: ExecutionEvent): void {
+  if (state.workflowId !== undefined) {
+    return;
+  }
+
+  state.workflowId = event.workflowId;
+  state.runId = event.runId;
+}
+
+function maybePromoteTopLevelWorkflow(state: RendererState, event: ExecutionEvent): void {
+  const parentInfo = extractParentInfo(event);
+  if (!parentInfo.parentWorkflowId) {
+    state.workflowId = event.workflowId;
+    state.runId = event.runId;
+  } else {
+    maybeSetRootWorkflow(state, event);
+  }
 }
 
 export function reduceExecutionEvent(
@@ -234,56 +554,169 @@ export function reduceExecutionEvent(
   maxHistoryRows: number,
   maxTimelineRows = 480
 ): void {
-  state.workflowId = event.workflowId;
-  state.runId = event.runId;
+  maybeSetRootWorkflow(state, event);
   state.updatedAt = event.timestamp;
   state.recentEvents.push(lineForEvent(event));
   state.recentEvents = state.recentEvents.slice(-maxRecentEvents);
 
   switch (event.type) {
-    case "workflow.started":
+    case "workflow.started": {
+      maybePromoteTopLevelWorkflow(state, event);
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId,
+        summary: event.summary,
+        ...extractParentInfo(event)
+      });
+      workflow.summary = event.summary;
+      workflow.name = inferWorkflowName(event.summary, event.workflowId);
+      workflow.status = "running";
+      workflow.startedAt ??= event.timestamp;
+      workflow.updatedAt = event.timestamp;
+      connectToParentWorkflow(state, workflow, event);
+
       state.status = "running";
-      state.startedAt = event.timestamp;
+      state.startedAt ??= event.timestamp;
       state.lastFailure = undefined;
       break;
-    case "workflow.completed":
-      state.status = event.status;
-      state.lastFailure = undefined;
+    }
+    case "workflow.completed": {
+      maybePromoteTopLevelWorkflow(state, event);
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId,
+        summary: event.summary,
+        ...extractParentInfo(event)
+      });
+      workflow.summary = event.summary;
+      workflow.name = inferWorkflowName(event.summary, event.workflowId);
+      workflow.status = "success";
+      workflow.completedAt = event.timestamp;
+      workflow.updatedAt = event.timestamp;
+      connectToParentWorkflow(state, workflow, event);
+
+      if (!workflow.parentWorkflowId) {
+        state.status = event.status;
+        state.lastFailure = undefined;
+      }
       state.activeTasks.clear();
       break;
-    case "workflow.failed":
-      state.status = event.status;
-      state.lastFailure = failureReasonForEvent(event) ?? state.lastFailure;
-      state.errorCount += 1;
+    }
+    case "workflow.failed": {
+      maybePromoteTopLevelWorkflow(state, event);
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId,
+        summary: event.summary,
+        ...extractParentInfo(event)
+      });
+      workflow.summary = event.summary;
+      workflow.name = inferWorkflowName(event.summary, event.workflowId);
+      workflow.status = "fail";
+      workflow.completedAt = event.timestamp;
+      workflow.updatedAt = event.timestamp;
+      connectToParentWorkflow(state, workflow, event);
+
+      if (!workflow.parentWorkflowId) {
+        state.status = event.status;
+        state.lastFailure = failureReasonForEvent(event) ?? state.lastFailure;
+        state.errorCount += 1;
+      }
       state.activeTasks.clear();
       break;
-    case "task.queued":
-      pushTaskHistory(state, event, maxHistoryRows);
+    }
+    case "branch.started": {
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId
+      });
+      const summary =
+        getMetaString(event, "subWorkflowKey") ??
+        event.summary ??
+        event.branchId;
+      const branch = ensureBranch(workflow, event.branchId, summary, event.timestamp);
+      branch.status = "running";
+      branch.startedAt = event.timestamp;
+      workflow.updatedAt = event.timestamp;
       break;
-    case "task.started":
-      state.currentTask = event.taskName;
-      state.activeTasks.add(event.taskName);
-      pushTaskHistory(state, event, maxHistoryRows);
+    }
+    case "branch.completed": {
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId
+      });
+      const branch = ensureBranch(workflow, event.branchId, event.summary, event.timestamp);
+      branch.summary = event.summary;
+      branch.status = event.status === "fail" ? "fail" : "success";
+      branch.completedAt = event.timestamp;
+      const childWorkflowId = getMetaString(event, "childWorkflowId");
+      const childRunId = getMetaString(event, "childRunId");
+      if (childWorkflowId) {
+        branch.childWorkflowId = childWorkflowId;
+      }
+      if (childRunId) {
+        branch.childRunId = childRunId;
+      }
+      workflow.updatedAt = event.timestamp;
       break;
-    case "task.completed":
-      state.activeTasks.delete(event.taskName);
-      state.completedTasks.push(event.taskName);
+    }
+    case "task.queued": {
+      const task = updateTaskStateFromEvent(state, event);
+      pushTaskHistory(state, event, maxHistoryRows, getTaskDurationMs(task, event.timestamp));
+      break;
+    }
+    case "task.started": {
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId
+      });
+      state.currentTask = workflow.parentWorkflowId
+        ? `${workflow.name}/${event.taskName}`
+        : event.taskName;
+      state.activeTasks.add(state.currentTask);
+      const task = updateTaskStateFromEvent(state, event);
+      pushTaskHistory(state, event, maxHistoryRows, getTaskDurationMs(task, event.timestamp));
+      break;
+    }
+    case "task.completed": {
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId
+      });
+      const activeLabel = workflow.parentWorkflowId
+        ? `${workflow.name}/${event.taskName}`
+        : event.taskName;
+      state.activeTasks.delete(activeLabel);
+      state.completedTasks.push(activeLabel);
       state.completedTasks = state.completedTasks.slice(-5);
-      pushTaskHistory(state, event, maxHistoryRows);
+      const task = updateTaskStateFromEvent(state, event);
+      pushTaskHistory(state, event, maxHistoryRows, getTaskDurationMs(task, event.timestamp));
       break;
-    case "task.failed":
-      state.activeTasks.delete(event.taskName);
+    }
+    case "task.failed": {
+      const workflow = ensureWorkflowNode(state, {
+        workflowId: event.workflowId,
+        runId: event.runId
+      });
+      const activeLabel = workflow.parentWorkflowId
+        ? `${workflow.name}/${event.taskName}`
+        : event.taskName;
+      state.activeTasks.delete(activeLabel);
       state.lastFailure =
         failureReasonForEvent(event) !== undefined
           ? `${event.taskName}: ${failureReasonForEvent(event)}`
           : `${event.taskName} failed`;
       state.errorCount += 1;
-      pushTaskHistory(state, event, maxHistoryRows);
+      const task = updateTaskStateFromEvent(state, event);
+      pushTaskHistory(state, event, maxHistoryRows, getTaskDurationMs(task, event.timestamp));
       break;
-    case "task.retry_scheduled":
+    }
+    case "task.retry_scheduled": {
+      const task = updateTaskStateFromEvent(state, event);
       state.retryCount += 1;
-      pushTaskHistory(state, event, maxHistoryRows);
+      pushTaskHistory(state, event, maxHistoryRows, getTaskDurationMs(task, event.timestamp));
       break;
+    }
     case "memory.before_step":
     case "memory.after_step":
     case "retrieval.performed":
@@ -291,9 +724,6 @@ export function reduceExecutionEvent(
     case "memory.merge":
     case "memory.archive":
     case "memory.expire":
-      state.memoryWrites += 1;
-      pushMemoryTimelineEvent(state, event, maxTimelineRows);
-      break;
     case "memory.compress":
       state.memoryWrites += 1;
       pushMemoryTimelineEvent(state, event, maxTimelineRows);
@@ -385,7 +815,10 @@ export function buildDebugTimelineText(payload: Record<string, unknown>, timesta
   const url = typeof payload.url === "string" ? payload.url : undefined;
   const status = typeof payload.status === "number" ? ` ${payload.status}` : "";
   const durationMs = typeof payload.durationMs === "number" ? ` ${payload.durationMs}ms` : "";
-  const requestId = typeof payload.requestId === "string" && payload.requestId.length > 0 ? ` ${payload.requestId}` : "";
+  const requestId =
+    typeof payload.requestId === "string" && payload.requestId.length > 0
+      ? ` ${payload.requestId}`
+      : "";
   const error = typeof payload.error === "string" ? ` ${payload.error}` : "";
 
   return `${formatClock(timestamp)} [${badge}] ${provider} ${method} ${clipUrl(url)}${status}${durationMs}${requestId}${error}`.trim();
@@ -503,9 +936,9 @@ export function truncateText(value: string, width: number): string {
     return value;
   }
 
-  if (width <= 1) {
+  if (width <= 3) {
     return value.slice(0, width);
   }
 
-  return `${value.slice(0, width - 1)}…`;
+  return `${value.slice(0, width - 3)}...`;
 }

--- a/src/renderer.ts
+++ b/src/renderer.ts
@@ -75,6 +75,10 @@ class DefaultCLIRenderer implements CLIRenderer {
     this.started = false;
   }
 
+  close(): void {
+    this.stop();
+  }
+
   resize(): void {
     if (this.resolvedMode === "compact") {
       this.scheduleRender();

--- a/src/types.ts
+++ b/src/types.ts
@@ -258,6 +258,10 @@ export type Artifact = {
   meta?: Record<string, unknown>;
 };
 
+export type RunArtifact = Artifact & {
+  bytes: Uint8Array;
+};
+
 export type AIChatMessageRole = "developer" | "system" | "user" | "assistant";
 
 export type AISessionMessage = {
@@ -482,9 +486,22 @@ export interface TaskLogger {
   emit(event: TaskLogEvent): void;
 }
 
+export type ExecutionHistorySnapshot = {
+  events: ExecutionEvent[];
+  taskLogs: TaskLogEvent[];
+  updatedAt?: number;
+};
+
+export interface ExecutionHistoryTracker extends ExecutionObserver {
+  snapshot(): ExecutionHistorySnapshot;
+  subscribe(listener: (snapshot: ExecutionHistorySnapshot) => void): () => void;
+  reset(): void;
+}
+
 export type CLIRendererOptions = {
   enabled?: boolean;
   mode?: "off" | "line" | "compact" | "ink" | "dashboard" | "jsonl" | "plain";
+  persistAfterCompletion?: boolean;
   stream?: NodeJS.WriteStream;
   errorStream?: NodeJS.WriteStream;
   debugLogStream?: NodeJS.ReadableStream;
@@ -500,6 +517,7 @@ export type CLIRendererOptions = {
 export interface CLIRenderer extends ExecutionObserver {
   start(): void;
   stop(finalStatus?: "success" | "fail"): void;
+  close(): void;
   resize?(width: number, height: number): void;
 }
 
@@ -558,6 +576,11 @@ export interface WorkflowContext {
   artifacts: ArtifactStore;
   log: TaskLogger;
   now: () => number;
+  runSubWorkflow(
+    key: string,
+    input: WorkflowInput,
+    options?: SubWorkflowRunOptions
+  ): Promise<CycleRunResult>;
 }
 
 export type RunOptions = {
@@ -567,9 +590,32 @@ export type RunOptions = {
   observers?: ExecutionObserver[];
 };
 
+export type SubWorkflowRunOptions = Omit<RunOptions, "observers"> & {
+  branchId?: string;
+  summary?: string;
+};
+
+export type CycleRunMemorySnapshot = {
+  records: MemoryRecord[];
+  activeRecords: MemoryRecord[];
+  archivedRecords: MemoryRecord[];
+  lifecycle: LifecycleReport;
+};
+
+export type CycleRunArtifactSnapshot = {
+  artifacts: RunArtifact[];
+};
+
+export type CycleRunResult = {
+  frame: ExecutionFrame;
+  memory: CycleRunMemorySnapshot;
+  artifacts: CycleRunArtifactSnapshot;
+  history: ExecutionHistorySnapshot;
+};
+
 export interface Cycle {
   register(key: string, workflow: WorkflowDefinition): void;
-  run(key: string, input: WorkflowInput, options?: RunOptions): Promise<{ frame: ExecutionFrame }>;
+  run(key: string, input: WorkflowInput, options?: RunOptions): Promise<CycleRunResult>;
 }
 
 export type CycleOptions = {

--- a/tests/cycle.test.ts
+++ b/tests/cycle.test.ts
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import {
   createCLIRenderer,
   createCycle,
+  createExecutionHistoryTracker,
   createWorkflowInput,
   InMemoryArtifactStore,
   InMemoryMemoryEngine,
@@ -48,6 +49,19 @@ describe("Cycle foundation MVP", () => {
 
     expect(result.frame.status).toBe("success");
     expect(result.frame.completedTasks).toEqual(["analyze", "publish"]);
+    expect(result.memory.records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          id: `memory.workflow.summary.${result.frame.workflowId}.analyze`
+        })
+      ])
+    );
+    expect(result.artifacts.artifacts).toHaveLength(1);
+    expect(result.artifacts.artifacts[0]?.name).toBe("report.md");
+    expect(new TextDecoder().decode(result.artifacts.artifacts[0]?.bytes)).toContain("# Cycle Report");
+    expect(result.history.events.some((event) => event.type === "workflow.started")).toBe(true);
+    expect(result.history.events.some((event) => event.type === "workflow.completed")).toBe(true);
+    expect(result.history.taskLogs.some((event) => event.message === "Starting analysis")).toBe(true);
 
     const summary = await memoryEngine.get(
       `memory.workflow.summary.${result.frame.workflowId}.analyze`,
@@ -225,5 +239,179 @@ describe("Cycle foundation MVP", () => {
         expect.stringContaining("memory.knowledge.raw.rag."),
       ])
     });
+  });
+
+  it("supports running sub workflows during task execution with branch tracking", async () => {
+    class ChildTask extends Task {
+      name = "childTask";
+      memoryPhase = "EXECUTION" as const;
+      memoryTaskType = "workflow" as const;
+
+      async run(ctx: WorkflowContext): Promise<TaskResult> {
+        await ctx.memory.write({
+          id: `memory.workflow.summary.${ctx.workflowId}.child`,
+          shard: "workflow",
+          kind: "summary",
+          payload: {
+            workflowId: ctx.workflowId,
+            currentStep: this.name,
+            history: [],
+            contextSummary: "child workflow completed"
+          },
+          description: "Child workflow summary",
+          keywords: ["child", "workflow"],
+          importance: 0.91,
+          workflowId: ctx.workflowId,
+          runId: ctx.runId,
+          sourceTask: this.name,
+          phase: this.memoryPhase,
+          taskType: this.memoryTaskType
+        });
+
+        const artifact = await ctx.artifacts.create({
+          name: "child.txt",
+          mimeType: "text/plain",
+          bytes: new TextEncoder().encode("child-result")
+        });
+
+        return {
+          status: "success",
+          output: {
+            artifactId: artifact.artifactId
+          }
+        };
+      }
+    }
+
+    class ParentTask extends Task {
+      name = "invokeChild";
+      memoryPhase = "EXECUTION" as const;
+      memoryTaskType = "workflow" as const;
+
+      async run(ctx: WorkflowContext): Promise<TaskResult> {
+        const child = await ctx.runSubWorkflow(
+          "child-workflow",
+          createWorkflowInput({
+            source: "parent"
+          }),
+          {
+            branchId: "branch.child",
+            summary: "invoke child workflow"
+          }
+        );
+
+        return {
+          status: "success",
+          output: {
+            childStatus: child.frame.status,
+            childArtifacts: child.artifacts.artifacts.map((artifact) => artifact.name),
+            childHistoryTypes: child.history.events.map((event) => event.type)
+          }
+        };
+      }
+    }
+
+    const ChildWorkflow: WorkflowDefinition = {
+      name: "child-workflow",
+      start: "childTask",
+      end: "end",
+      tasks: {
+        childTask: new ChildTask()
+      },
+      transitions: {
+        childTask: {
+          success: "end"
+        }
+      }
+    };
+
+    const ParentWorkflow: WorkflowDefinition = {
+      name: "parent-workflow",
+      start: "invokeChild",
+      end: "end",
+      tasks: {
+        invokeChild: new ParentTask()
+      },
+      transitions: {
+        invokeChild: {
+          success: "end"
+        }
+      }
+    };
+
+    const cycle = createCycle();
+    cycle.register("child-workflow", ChildWorkflow);
+    cycle.register("parent-workflow", ParentWorkflow);
+
+    const result = await cycle.run("parent-workflow", createWorkflowInput());
+    const childOutput = result.frame.taskResults.invokeChild?.output as
+      | {
+          childStatus: string;
+          childArtifacts: string[];
+          childHistoryTypes: string[];
+        }
+      | undefined;
+
+    expect(result.frame.status).toBe("success");
+    expect(childOutput).toMatchObject({
+      childStatus: "success",
+      childArtifacts: ["child.txt"]
+    });
+    expect(childOutput).toHaveProperty("childHistoryTypes");
+    expect(childOutput?.childHistoryTypes).toEqual(
+      expect.arrayContaining([
+        "branch.started",
+        "workflow.started",
+        "workflow.completed"
+      ])
+    );
+    expect(
+      result.history.events.some(
+        (event) => event.type === "branch.started" && event.branchId === "branch.child"
+      )
+    ).toBe(true);
+    expect(
+      result.history.events.some(
+        (event) => event.type === "branch.completed" && event.branchId === "branch.child"
+      )
+    ).toBe(true);
+    expect(
+      result.history.events.some(
+        (event) =>
+          event.type === "workflow.started" &&
+          event.meta?.["parentWorkflowId"] === result.frame.workflowId
+      )
+    ).toBe(true);
+  });
+
+  it("tracks execution history in real time through the tracker interface", async () => {
+    const tracker = createExecutionHistoryTracker();
+    const snapshots: number[] = [];
+    const unsubscribe = tracker.subscribe((snapshot) => {
+      snapshots.push(snapshot.events.length + snapshot.taskLogs.length);
+    });
+
+    const cycle = createCycle({
+      observers: [tracker],
+      now: (() => {
+        let current = 9_000;
+        return () => ++current;
+      })()
+    });
+    cycle.register("report", ReportWorkflow);
+
+    const result = await cycle.run(
+      "report",
+      createWorkflowInput({
+        text: "Track workflow execution updates"
+      })
+    );
+
+    unsubscribe();
+
+    expect(result.frame.status).toBe("success");
+    expect(snapshots.length).toBeGreaterThan(1);
+    expect(tracker.snapshot().events.some((event) => event.type === "workflow.completed")).toBe(true);
+    expect(tracker.snapshot().taskLogs.some((event) => event.message === "Artifact created")).toBe(true);
   });
 });

--- a/tests/ink-renderer.test.tsx
+++ b/tests/ink-renderer.test.tsx
@@ -27,9 +27,9 @@ function createInkState(): RendererState {
     workflowId: "java-modernization",
     runId: "run_ink",
     summary: "java modernization start=analyze"
-  }, 10, 32, 64);
+  }, 10, 64, 128);
 
-  for (let index = 1; index <= 6; index += 1) {
+  for (let index = 1; index <= 8; index += 1) {
     reduceExecutionEvent(state, {
       type: "task.started",
       timestamp: Date.UTC(2026, 2, 29, 9, 0, index),
@@ -37,49 +37,121 @@ function createInkState(): RendererState {
       runId: "run_ink",
       taskName: `task-${index}`,
       summary: `history-item-${index}`
-    }, 10, 32, 64);
+    }, 10, 64, 128);
+
+    if (index < 8) {
+      reduceExecutionEvent(state, {
+        type: "task.completed",
+        timestamp: Date.UTC(2026, 2, 29, 9, 0, index) + 800,
+        workflowId: "java-modernization",
+        runId: "run_ink",
+        taskName: `task-${index}`,
+        summary: `history-item-${index}-done`,
+        status: "success"
+      }, 10, 64, 128);
+    }
   }
 
   reduceExecutionEvent(state, {
-    type: "retrieval.performed",
-    timestamp: Date.UTC(2026, 2, 29, 9, 1, 58),
+    type: "branch.started",
+    timestamp: Date.UTC(2026, 2, 29, 9, 0, 20),
     workflowId: "java-modernization",
     runId: "run_ink",
-    summary: "retrieve workflow",
+    branchId: "branch.refactor",
+    summary: "invoke child workflow",
     meta: {
-      routedShards: ["workflow", "task"],
-      hitCount: 2,
-      usedTokens: 48
+      subWorkflowKey: "child-refactor"
     }
-  }, 10, 32, 64);
+  }, 10, 64, 128);
+
   reduceExecutionEvent(state, {
-    type: "memory.compress",
-    timestamp: Date.UTC(2026, 2, 29, 9, 1, 59),
+    type: "workflow.started",
+    timestamp: Date.UTC(2026, 2, 29, 9, 0, 21),
+    workflowId: "child-refactor-aa11bb22",
+    runId: "run_child",
+    summary: "child refactor start=scan",
+    meta: {
+      parentWorkflowId: "java-modernization",
+      parentRunId: "run_ink",
+      branchId: "branch.refactor"
+    }
+  }, 10, 64, 128);
+
+  reduceExecutionEvent(state, {
+    type: "task.started",
+    timestamp: Date.UTC(2026, 2, 29, 9, 0, 22),
+    workflowId: "child-refactor-aa11bb22",
+    runId: "run_child",
+    taskName: "scan",
+    summary: "child-start",
+    meta: {
+      parentWorkflowId: "java-modernization",
+      parentRunId: "run_ink",
+      branchId: "branch.refactor"
+    }
+  }, 10, 64, 128);
+
+  reduceExecutionEvent(state, {
+    type: "task.completed",
+    timestamp: Date.UTC(2026, 2, 29, 9, 0, 24),
+    workflowId: "child-refactor-aa11bb22",
+    runId: "run_child",
+    taskName: "scan",
+    summary: "child-done",
+    status: "success",
+    meta: {
+      parentWorkflowId: "java-modernization",
+      parentRunId: "run_ink",
+      branchId: "branch.refactor"
+    }
+  }, 10, 64, 128);
+
+  reduceExecutionEvent(state, {
+    type: "workflow.completed",
+    timestamp: Date.UTC(2026, 2, 29, 9, 0, 25),
+    workflowId: "child-refactor-aa11bb22",
+    runId: "run_child",
+    summary: "child refactor completed",
+    status: "success",
+    meta: {
+      parentWorkflowId: "java-modernization",
+      parentRunId: "run_ink",
+      branchId: "branch.refactor"
+    }
+  }, 10, 64, 128);
+
+  reduceExecutionEvent(state, {
+    type: "branch.completed",
+    timestamp: Date.UTC(2026, 2, 29, 9, 0, 26),
     workflowId: "java-modernization",
     runId: "run_ink",
-    summary: "lifecycle compress",
+    branchId: "branch.refactor",
+    summary: "invoke child workflow",
+    status: "success",
     meta: {
-      compressedIds: ["memory.task.summary.compressed.demo"]
+      childWorkflowId: "child-refactor-aa11bb22",
+      childRunId: "run_child"
     }
-  }, 10, 32, 64);
+  }, 10, 64, 128);
 
   for (let index = 1; index <= 12; index += 1) {
     pushTaskLog(state, {
       timestamp: Date.UTC(2026, 2, 29, 9, 1, index),
       workflowId: "java-modernization",
       runId: "run_ink",
-      taskName: `task-${((index - 1) % 6) + 1}`,
+      taskName: `task-${((index - 1) % 8) + 1}`,
       level: index === 12 ? "success" : "info",
       message: `timeline-log-${index}`
-    }, 24, 64);
+    }, 24, 128);
   }
 
   pushDebugLogLine(
     state,
     `[cycle:http] {"phase":"request","provider":"gemini","method":"POST","url":"https://generativelanguage.googleapis.com/v1beta/openai/chat/completions","requestId":"req_ink"}`,
     Date.UTC(2026, 2, 29, 9, 2, 0),
-    64
+    128
   );
+
   reduceExecutionEvent(state, {
     type: "retrieval.performed",
     timestamp: Date.UTC(2026, 2, 29, 9, 2, 1),
@@ -91,29 +163,19 @@ function createInkState(): RendererState {
       hitCount: 2,
       usedTokens: 48
     }
-  }, 10, 32, 64);
-  reduceExecutionEvent(state, {
-    type: "memory.compress",
-    timestamp: Date.UTC(2026, 2, 29, 9, 2, 2),
-    workflowId: "java-modernization",
-    runId: "run_ink",
-    summary: "lifecycle compress",
-    meta: {
-      compressedIds: ["memory.task.summary.compressed.demo"]
-    }
-  }, 10, 32, 64);
+  }, 10, 64, 128);
 
   return state;
 }
 
 describe("Ink renderer screen", () => {
-  it("renders workflow summary, task history, and debug timeline rows", async () => {
+  it("renders workflow flowchart, branch nesting, task durations, and logs", async () => {
     const state = createInkState();
     const instance = render(
       <InkRendererScreen
         state={state}
-        columns={100}
-        rows={14}
+        columns={110}
+        rows={20}
         finalStatus={undefined}
       />
     );
@@ -122,25 +184,28 @@ describe("Ink renderer screen", () => {
       await flushInk();
       const frame = instance.lastFrame();
 
-      expect(frame).toContain("Cycle Ink");
-      expect(frame).toContain("Workflow + History");
-      expect(frame).toContain("Logs (17)");
-      expect(frame).toContain("focus=right");
+      expect(frame).toContain("워크플로우 파이프라인 플로우차트");
+      expect(frame).toContain("워크플로우 task 실행 이력");
+      expect(frame).toContain("실행 로그");
+      expect(frame).toContain("java modernization [RUNNING");
+      expect(frame).toContain("┌────────────────┐");
+      expect(frame).toContain("DONE 800ms");
+      expect(frame).toContain("└─ branch.refactor");
+      expect(frame).toContain("child refactor [SUCCESS");
       expect(frame).toContain("[REQ] gemini POST");
       expect(frame).toContain("[MEM] retrieve");
-      expect(frame).toContain("follow=on");
     } finally {
       instance.unmount();
     }
   });
 
-  it("supports pane focus changes and scrolling with keyboard input", async () => {
+  it("supports bottom pane focus changes and scrolling with keyboard input", async () => {
     const state = createInkState();
     const instance = render(
       <InkRendererScreen
         state={state}
-        columns={100}
-        rows={14}
+        columns={110}
+        rows={18}
         finalStatus={undefined}
       />
     );
@@ -158,7 +223,7 @@ describe("Ink renderer screen", () => {
 
       instance.stdin.write("G");
       await flushInk();
-      expect(instance.lastFrame()).toContain("history-item-6");
+      expect(instance.lastFrame()).toContain("history-item-8");
 
       instance.stdin.write("\t");
       await flushInk();

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -207,4 +207,108 @@ describe("CLI renderer", () => {
       }
     }
   });
+
+  it("keeps Ink terminal state after stop until close is called", () => {
+    const ttyLike = stream as unknown as NodeJS.WriteStream & {
+      isTTY?: boolean;
+      columns?: number;
+      rows?: number;
+      on?: (event: string, listener: (...args: unknown[]) => void) => void;
+      off?: (event: string, listener: (...args: unknown[]) => void) => void;
+    };
+    ttyLike.isTTY = true;
+    ttyLike.columns = 100;
+    ttyLike.rows = 30;
+    ttyLike.on = ((..._args: unknown[]) => ttyLike) as typeof ttyLike.on;
+    ttyLike.off = ((..._args: unknown[]) => ttyLike) as typeof ttyLike.off;
+
+    const renderer = new InkCLIRenderer({
+      enabled: true,
+      mode: "ink",
+      persistAfterCompletion: true,
+      stream: ttyLike,
+      errorStream: ttyLike
+    }) as InkCLIRenderer & Record<string, unknown>;
+
+    let leaveCalls = 0;
+    let summaryCalls = 0;
+
+    renderer["attachResizeHandler"] = () => undefined;
+    renderer["attachDebugStream"] = () => undefined;
+    renderer["renderNow"] = () => undefined;
+    renderer["enterAlternateScreen"] = () => undefined;
+    renderer["leaveAlternateScreen"] = () => {
+      leaveCalls += 1;
+    };
+    renderer["writeFinalSummary"] = () => {
+      summaryCalls += 1;
+    };
+
+    renderer.start();
+    renderer.stop("success");
+
+    expect(leaveCalls).toBe(0);
+    expect(summaryCalls).toBe(0);
+
+    renderer.close();
+
+    expect(leaveCalls).toBe(1);
+    expect(summaryCalls).toBe(1);
+  });
+
+  it("handles Ctrl+C by closing Ink silently and exiting the process", () => {
+    const ttyLike = stream as unknown as NodeJS.WriteStream & {
+      isTTY?: boolean;
+      columns?: number;
+      rows?: number;
+      on?: typeof stream.on;
+      off?: typeof stream.off;
+    };
+    ttyLike.isTTY = true;
+    ttyLike.columns = 100;
+    ttyLike.rows = 30;
+    ttyLike.on = ((..._args: Parameters<typeof stream.on>) => ttyLike) as typeof ttyLike.on;
+    ttyLike.off = ((..._args: Parameters<typeof stream.off>) => ttyLike) as typeof ttyLike.off;
+
+    const renderer = new InkCLIRenderer({
+      enabled: true,
+      mode: "ink",
+      persistAfterCompletion: true,
+      stream: ttyLike,
+      errorStream: ttyLike
+    }) as InkCLIRenderer & Record<string, unknown>;
+
+    let leaveCalls = 0;
+    let summaryCalls = 0;
+    let exitCode: number | undefined;
+
+    renderer["attachResizeHandler"] = () => undefined;
+    renderer["attachDebugStream"] = () => undefined;
+    renderer["renderNow"] = () => undefined;
+    renderer["enterAlternateScreen"] = () => undefined;
+    renderer["leaveAlternateScreen"] = () => {
+      leaveCalls += 1;
+    };
+    renderer["writeFinalSummary"] = () => {
+      summaryCalls += 1;
+    };
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      return undefined as never;
+    }) as typeof process.exit;
+
+    try {
+      renderer.start();
+      const signalHandler = renderer["processSignalHandler"] as (() => void) | undefined;
+      signalHandler?.();
+    } finally {
+      process.exit = originalExit;
+    }
+
+    expect(leaveCalls).toBe(1);
+    expect(summaryCalls).toBe(0);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary
- extend `cycle.run()` to return memory, artifact, and history snapshots
- add sub-workflow branching and real-time execution history tracking
- upgrade the Ink renderer with a flowchart layout, branch-aware rendering, task durations, and persistent session handling with clean Ctrl+C shutdown
- add a sample project that demonstrates derived sub-workflow execution

## Validation
- npm run typecheck
- npm test
- npm run build
- npm --prefix sample-project run typecheck
