### PR TITLE
[codex] fix: restore sub-workflow sample imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "import": "./dist/index.js",
       "default": "./dist/index.js"
     }
   },

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -14,6 +14,8 @@ npm install
 ```
 
 ## 실행
+모든 `start*` 스크립트는 실행 전에 라이브러리 build 를 자동으로 갱신한다.
+
 기본 설정 파일 사용:
 ```bash
 OPENAI_API_KEY=your_key_here npm run start

--- a/sample-project/package.json
+++ b/sample-project/package.json
@@ -6,14 +6,13 @@
   "scripts": {
     "build:library": "npm --prefix .. run build",
     "typecheck": "tsc -p tsconfig.json --noEmit",
-    "prestart": "npm run build:library",
-    "start": "tsx ./src/main.ts",
-    "start:line": "CYCLE_LIVE=0 tsx ./src/main.ts",
-    "start:ink": "CYCLE_RENDER_MODE=ink tsx ./src/main.ts",
-    "start:stream": "tsx ./src/main-stream.ts",
-    "start:sub": "tsx ./src/main-sub-workflow.ts",
-    "start:sub:line": "CYCLE_LIVE=0 tsx ./src/main-sub-workflow.ts",
-    "start:sub:ink": "cross-env CYCLE_RENDER_MODE=ink tsx ./src/main-sub-workflow.ts"
+    "start": "npm run build:library && tsx ./src/main.ts",
+    "start:line": "npm run build:library && CYCLE_LIVE=0 tsx ./src/main.ts",
+    "start:ink": "npm run build:library && CYCLE_RENDER_MODE=ink tsx ./src/main.ts",
+    "start:stream": "npm run build:library && tsx ./src/main-stream.ts",
+    "start:sub": "npm run build:library && tsx ./src/main-sub-workflow.ts",
+    "start:sub:line": "npm run build:library && CYCLE_LIVE=0 tsx ./src/main-sub-workflow.ts",
+    "start:sub:ink": "npm run build:library && cross-env CYCLE_RENDER_MODE=ink tsx ./src/main-sub-workflow.ts"
   },
   "dependencies": {
     "agentic-task-kit": "file:..",

--- a/scripts/build-package.mjs
+++ b/scripts/build-package.mjs
@@ -1,12 +1,15 @@
 import { builtinModules } from "node:module";
+import { mkdir, readdir, stat, writeFile } from "node:fs/promises";
+import { dirname, join, relative } from "node:path";
 
 import { build } from "esbuild";
 
 const external = builtinModules.flatMap((name) => [name, `node:${name}`]);
+const distDir = "dist";
 
 await build({
   entryPoints: ["src/index.ts"],
-  outfile: "dist/index.js",
+  outfile: `${distDir}/index.js`,
   bundle: true,
   platform: "node",
   format: "esm",
@@ -18,3 +21,48 @@ await build({
   },
   external
 });
+
+const declarationFiles = await listDeclarationFiles(distDir);
+
+for (const declarationFile of declarationFiles) {
+  if (declarationFile === join(distDir, "index.d.ts")) {
+    continue;
+  }
+
+  const shimPath = declarationFile.replace(/\.d\.ts$/u, ".js");
+  const relativeIndexPath = relative(dirname(shimPath), join(distDir, "index.js"));
+  const importPath = relativeIndexPath.startsWith(".")
+    ? relativeIndexPath
+    : `./${relativeIndexPath}`;
+
+  await mkdir(dirname(shimPath), { recursive: true });
+  await writeFile(shimPath, `export * from ${JSON.stringify(importPath)};\n`, "utf8");
+}
+
+async function listDeclarationFiles(rootDir) {
+  const entries = await readdir(rootDir, { withFileTypes: true });
+  const files = [];
+
+  for (const entry of entries) {
+    const absolutePath = join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listDeclarationFiles(absolutePath)));
+      continue;
+    }
+
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const details = await stat(absolutePath);
+    if (!details.isFile()) {
+      continue;
+    }
+
+    if (absolutePath.endsWith(".d.ts")) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}


### PR DESCRIPTION
## Summary
- add ESM import resolution for the bundled package export
- generate runtime shim modules for dist declaration re-export paths
- make all sample-project start scripts rebuild the library before execution

## Verification
- npm run typecheck
- npm run build
- npm --prefix sample-project run typecheck
- npm run start:sub
- npm run start:sub:line
- npm pack --dry-run