### PR TITLE
[codex] feat: cancel active workflows on ctrl-c

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_REN
 - `PageUp/PageDown`: 페이지 단위 스크롤
 - `Home/End`, `g/G`: 처음/끝 이동
 - `CYCLE_LOG_LEVEL=debug`: task debug log 와 provider HTTP debug log 노출
+- workflow 실행 중 `Ctrl+C`: 현재 active workflow 와 sub-workflow 에 cancel signal 전파
+- idle 상태 `Ctrl+C`: Ink terminal reset 후 프로세스 종료
 
 interactive TTY 가 아니면 `ink` 모드는 `jsonl` 로 자동 fallback 된다.
 
@@ -188,6 +190,26 @@ const input = createWorkflowInput({
 });
 
 await cycle.run("report", input);
+```
+
+## Workflow Cancellation
+`WorkflowContext.cancellation.signal` 로 현재 workflow run 의 cancel signal 을 읽을 수 있다. `ink` mode 에서는 `Ctrl+C` 가 active workflow 를 먼저 cancel 하고, active workflow 가 없을 때만 terminal reset + exit 를 수행한다.
+
+```ts
+class LongTask extends Task {
+  name = "longTask";
+  memoryPhase = "EXECUTION" as const;
+  memoryTaskType = "workflow" as const;
+
+  async run(ctx: WorkflowContext): Promise<TaskResult> {
+    ctx.cancellation.throwIfRequested();
+    const result = await ctx.ai.chat({
+      messages: [{ role: "user", content: "Do work" }]
+    });
+    ctx.cancellation.throwIfRequested();
+    return { status: "success", output: result.outputText };
+  }
+}
 ```
 
 ## Run Result Snapshot

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -39,6 +39,7 @@ CYCLE_LIVE=0 npm run example
 
 Ink mode 에서는 좌측에 workflow/task history, 우측에 task log + provider debug log 가 2컬럼으로 출력된다.
 `Tab`, `↑↓`, `j k`, `PageUp/PageDown`, `Home/End`, `g/G` 를 지원한다.
+workflow 실행 중 `Ctrl+C` 는 active workflow cancel 을 우선하고, idle 상태에서는 terminal reset + exit 를 수행한다.
 TTY 가 아니면 `jsonl` 로 fallback 된다.
 
 ## Bundle build

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -80,4 +80,4 @@ OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_REN
 - child workflow: `service-analysis`
 - branch id: `branch.service-analysis`
 
-Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행이 끝난 뒤에도 Ink 세션은 유지되며, `Ctrl+C` 입력이 들어오면 터미널 출력을 오염시키지 않게 Ink session 을 닫고 프로세스를 종료한다.
+Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행 중 `Ctrl+C` 를 누르면 현재 active workflow 와 child workflow 에 cancel signal 이 먼저 전달되고, workflow 가 더 이상 없을 때 다음 `Ctrl+C` 가 Ink session 을 닫고 프로세스를 종료한다.

--- a/src/cycle.ts
+++ b/src/cycle.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "node:crypto";
 
 import { createUnavailableAIProvider } from "./ai.js";
 import { createObservedArtifactStore, InMemoryArtifactStore } from "./artifacts.js";
+import { toWorkflowCancellationError } from "./errors.js";
 import { ExecutionBroadcaster } from "./events.js";
 import { createExecutionHistoryTracker } from "./history.js";
 import { createTaskLogger } from "./logging.js";
@@ -12,7 +13,12 @@ import {
   InMemoryMemoryEngine,
   InMemoryVectorStore
 } from "./memory.js";
+import {
+  registerGlobalWorkflowRun,
+  WorkflowRunControl
+} from "./runtime-control.js";
 import type {
+  AIChatRequest,
   AIProvider,
   AISession,
   AISessionMessage,
@@ -98,6 +104,123 @@ function ensureSequentialOnly(
   }
 
   throw new Error("Parallel transitions are not implemented in the Foundation MVP.");
+}
+
+function combineAbortSignals(signals: Array<AbortSignal | undefined>): AbortSignal | undefined {
+  const activeSignals = signals.filter((signal): signal is AbortSignal => signal !== undefined);
+  if (activeSignals.length === 0) {
+    return undefined;
+  }
+
+  if (activeSignals.length === 1) {
+    return activeSignals[0];
+  }
+
+  if (typeof AbortSignal.any === "function") {
+    return AbortSignal.any(activeSignals);
+  }
+
+  const controller = new AbortController();
+  const cleanup = (): void => {
+    for (const signal of activeSignals) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  };
+  const onAbort = (event: Event): void => {
+    const signal = event.target as AbortSignal;
+    cleanup();
+    controller.abort(signal.reason);
+  };
+
+  for (const signal of activeSignals) {
+    if (signal.aborted) {
+      controller.abort(signal.reason);
+      return controller.signal;
+    }
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  }
+
+  return controller.signal;
+}
+
+function withWorkflowAbortSignal(
+  request: AIChatRequest,
+  workflowSignal: AbortSignal
+): AIChatRequest {
+  const signal = combineAbortSignals([workflowSignal, request.http?.signal]);
+  if (!signal) {
+    return request;
+  }
+
+  return {
+    ...request,
+    http: {
+      ...request.http,
+      signal
+    }
+  };
+}
+
+function createAbortAwareAIProvider(provider: AIProvider, workflowSignal: AbortSignal): AIProvider {
+  return {
+    provider: provider.provider,
+    defaultChatModel: provider.defaultChatModel,
+    chat: (request) => provider.chat(withWorkflowAbortSignal(request, workflowSignal)),
+    chatStream: (request) => provider.chatStream(withWorkflowAbortSignal(request, workflowSignal))
+  };
+}
+
+function toSerializableErrorDetails(error: unknown): unknown {
+  if (!(error instanceof Error)) {
+    return error;
+  }
+
+  const details: Record<string, unknown> = {
+    name: error.name,
+    message: error.message,
+    stack: error.stack
+  };
+  const code = "code" in error ? (error as { code?: unknown }).code : undefined;
+  if (typeof code === "string") {
+    details.code = code;
+  }
+
+  return details;
+}
+
+function toFailureResult(error: unknown, control: WorkflowRunControl): TaskResult {
+  if (control.isCancellationRequested()) {
+    const cancellationError = toWorkflowCancellationError(control.reason);
+    return {
+      status: "fail",
+      error: {
+        message: cancellationError.message,
+        code: cancellationError.code,
+        details: toSerializableErrorDetails(error)
+      }
+    };
+  }
+
+  if (error instanceof Error) {
+    return {
+      status: "fail",
+      error: {
+        message: error.message,
+        ...(("code" in error && typeof (error as { code?: unknown }).code === "string")
+          ? { code: (error as { code: string }).code }
+          : {}),
+        details: toSerializableErrorDetails(error)
+      }
+    };
+  }
+
+  return {
+    status: "fail",
+    error: {
+      message: String(error)
+    }
+  };
 }
 
 function toRagMemoryRecord(
@@ -221,6 +344,7 @@ type InternalRunOptions = {
   broadcaster?: ExecutionBroadcaster;
   historyTracker: ExecutionHistoryTracker;
   parent?: ParentRunContext;
+  control: WorkflowRunControl;
 };
 
 class DefaultCycle implements Cycle {
@@ -232,6 +356,7 @@ class DefaultCycle implements Cycle {
   private readonly now: () => number;
   private readonly llmModelId: string;
   private readonly embeddingModelId: string;
+  private readonly activeRuns = new Map<string, WorkflowRunControl>();
 
   constructor(options: CycleOptions = {}) {
     this.aiProvider = options.aiProvider ?? createUnavailableAIProvider();
@@ -258,11 +383,41 @@ class DefaultCycle implements Cycle {
     this.workflows.set(key, workflow);
   }
 
+  hasActiveRuns(): boolean {
+    for (const run of this.activeRuns.values()) {
+      if (run.isActive()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async cancelActiveRuns(reason = "Workflow cancelled by Ctrl+C."): Promise<number> {
+    let cancelled = 0;
+    for (const run of this.activeRuns.values()) {
+      if (!run.isActive()) {
+        continue;
+      }
+
+      if (run.cancel(reason)) {
+        cancelled += 1;
+      }
+    }
+
+    return cancelled;
+  }
+
   async run(
     key: string,
     input: WorkflowInput,
     options: RunOptions = {},
   ): Promise<CycleRunResult> {
+    const controlKey = randomUUID();
+    const control = new WorkflowRunControl();
+    this.activeRuns.set(controlKey, control);
+    const unregisterGlobalRun = registerGlobalWorkflowRun(control);
+
     const historyTracker = createExecutionHistoryTracker();
     const runBroadcaster = new ExecutionBroadcaster([
       ...this.broadcaster.listObservers(),
@@ -279,11 +434,15 @@ class DefaultCycle implements Cycle {
         input,
         options,
         broadcaster: runBroadcaster,
-        historyTracker
+        historyTracker,
+        control
       });
       finalStatus = result.frame.status === "success" ? "success" : "fail";
       return result;
     } finally {
+      control.complete();
+      unregisterGlobalRun();
+      this.activeRuns.delete(controlKey);
       await runBroadcaster.stop(finalStatus);
     }
   }
@@ -293,8 +452,10 @@ class DefaultCycle implements Cycle {
     key: string,
     input: WorkflowInput,
     broadcaster: ExecutionBroadcaster,
+    control: WorkflowRunControl,
     options: SubWorkflowRunOptions = {},
   ): Promise<CycleRunResult> {
+    control.throwIfRequested();
     const branchId = options.branchId ?? `branch_${randomUUID().slice(0, 8)}`;
     const historyTracker = createExecutionHistoryTracker();
     broadcaster.addObserver(historyTracker);
@@ -324,6 +485,7 @@ class DefaultCycle implements Cycle {
         options,
         broadcaster,
         historyTracker,
+        control,
         parent: {
           ...parent,
           branchId
@@ -372,6 +534,7 @@ class DefaultCycle implements Cycle {
     if (!workflow) {
       throw new Error(`Workflow "${args.key}" is not registered.`);
     }
+    args.control.throwIfRequested();
 
     const runBroadcaster = args.broadcaster;
     if (!runBroadcaster) {
@@ -400,6 +563,7 @@ class DefaultCycle implements Cycle {
       }
     });
     let lifecycleReport = EMPTY_LIFECYCLE_REPORT;
+    const abortAwareAIProvider = createAbortAwareAIProvider(this.aiProvider, args.control.signal);
 
     const meta =
       args.parent
@@ -427,6 +591,7 @@ class DefaultCycle implements Cycle {
 
     try {
       while (frame.currentState !== endState) {
+        args.control.throwIfRequested();
         const task = workflow.tasks[frame.currentState];
         if (!task) {
           throw new Error(
@@ -472,17 +637,19 @@ class DefaultCycle implements Cycle {
           input: args.input,
           now: this.now()
         });
+        args.control.throwIfRequested();
 
         const context: WorkflowContext = {
           workflowId,
           runId,
           input: args.input,
           session: createSession(this.llmModelId, this.embeddingModelId),
-          ai: this.aiProvider,
+          ai: abortAwareAIProvider,
           memory,
           memoryContext,
           artifacts,
           log,
+          cancellation: args.control,
           now: this.now,
           runSubWorkflow: (key, input, options) =>
             this.runSubWorkflow(
@@ -493,29 +660,29 @@ class DefaultCycle implements Cycle {
               key,
               input,
               runBroadcaster,
+              args.control,
               options
             )
         };
 
-        if (task.before) {
-          await task.before(context);
-        }
-
         let result: TaskResult;
         try {
+          args.control.throwIfRequested();
+          if (task.before) {
+            await task.before(context);
+          }
+          args.control.throwIfRequested();
           result = await task.run(context);
         } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          result = {
-            status: "fail",
-            error: {
-              message
-            }
-          };
+          result = toFailureResult(error, args.control);
         }
 
-        if (task.after) {
-          await task.after(context, result);
+        try {
+          if (task.after) {
+            await task.after(context, result);
+          }
+        } catch (error) {
+          result = toFailureResult(error, args.control);
         }
 
         await memory.afterStep({
@@ -634,10 +801,15 @@ class DefaultCycle implements Cycle {
         history: args.historyTracker
       });
     } catch (error) {
-      const message = error instanceof Error ? error.message : String(error);
+      const normalizedError = args.control.isCancellationRequested()
+        ? toWorkflowCancellationError(args.control.reason)
+        : error;
+      const message =
+        normalizedError instanceof Error ? normalizedError.message : String(normalizedError);
       frame.status = "fail";
       frame.errors.push(message);
       frame.updatedAt = this.now();
+      lifecycleReport = await memory.runLifecycle(this.now());
 
       await runBroadcaster.emit({
         type: "workflow.failed",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,5 +1,7 @@
 import type { AIProviderRequestErrorDetails } from "./types.js";
 
+const DEFAULT_WORKFLOW_CANCELLATION_MESSAGE = "Workflow cancelled by Ctrl+C.";
+
 function safeStringify(value: unknown): string {
   if (typeof value === "string") {
     return value;
@@ -96,4 +98,38 @@ export class AIProviderRequestError extends Error {
           : this.originalError
     };
   }
+}
+
+export class WorkflowCancellationError extends Error {
+  readonly code = "ABORTED";
+
+  constructor(message = DEFAULT_WORKFLOW_CANCELLATION_MESSAGE, options?: { cause?: unknown }) {
+    super(message, {
+      cause: options?.cause instanceof Error ? options.cause : undefined
+    });
+
+    this.name = "WorkflowCancellationError";
+  }
+}
+
+export function isWorkflowCancellationError(error: unknown): error is WorkflowCancellationError {
+  return error instanceof WorkflowCancellationError;
+}
+
+export function toWorkflowCancellationError(reason?: unknown): WorkflowCancellationError {
+  if (reason instanceof WorkflowCancellationError) {
+    return reason;
+  }
+
+  if (reason instanceof Error) {
+    return new WorkflowCancellationError(reason.message || DEFAULT_WORKFLOW_CANCELLATION_MESSAGE, {
+      cause: reason
+    });
+  }
+
+  if (typeof reason === "string" && reason.trim().length > 0) {
+    return new WorkflowCancellationError(reason);
+  }
+
+  return new WorkflowCancellationError(DEFAULT_WORKFLOW_CANCELLATION_MESSAGE);
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,11 @@
 export { createCycle } from "./cycle.js";
 export { createUnavailableAIProvider } from "./ai.js";
-export { AIProviderRequestError } from "./errors.js";
+export {
+  AIProviderRequestError,
+  WorkflowCancellationError,
+  isWorkflowCancellationError,
+  toWorkflowCancellationError
+} from "./errors.js";
 export { ExecutionBroadcaster } from "./events.js";
 export { createExecutionHistoryTracker } from "./history.js";
 export { createTaskLogger } from "./logging.js";
@@ -13,6 +18,7 @@ export {
   InMemoryVectorStore
 } from "./memory.js";
 export { InMemoryArtifactStore, createObservedArtifactStore } from "./artifacts.js";
+export { getGlobalWorkflowRuntimeController } from "./runtime-control.js";
 export {
   createOpenAICompatibleChatProviderFromConfigFile,
   loadOpenAICompatibleChatProviderOptionsFromConfigFile,
@@ -111,6 +117,8 @@ export type {
   TaskStatus,
   Transition,
   WorkflowContext,
+  WorkflowCancellation,
+  WorkflowRuntimeController,
   WorkflowInput,
   WorkflowDefinition
 } from "./types.js";

--- a/src/ink-renderer.tsx
+++ b/src/ink-renderer.tsx
@@ -3,6 +3,7 @@ import { createInterface, type Interface as ReadLineInterface } from "node:readl
 import { render, Text, useInput } from "ink";
 import { useEffect, useState, type ReactElement } from "react";
 
+import { getGlobalWorkflowRuntimeController } from "./runtime-control.js";
 import {
   createInitialRendererState,
   formatDuration,
@@ -469,6 +470,7 @@ type InkRendererResolvedOptions = Required<
 > & {
   stream: NodeJS.WriteStream;
   errorStream: NodeJS.WriteStream;
+  workflowController: NonNullable<CLIRendererOptions["workflowController"]>;
   debugLogStream?: NodeJS.ReadableStream;
 };
 
@@ -484,7 +486,13 @@ export class InkCLIRenderer implements CLIRenderer {
   private inkInstance: ReturnType<typeof render> | null = null;
   private debugLineReader: ReadLineInterface | null = null;
   private resizeHandler: (() => void) | null = null;
+  private interruptCancellationRequested = false;
   private readonly processSignalHandler = (): void => {
+    if (this.options.workflowController.hasActiveRuns()) {
+      this.requestWorkflowCancellation();
+      return;
+    }
+
     this.shutdown({
       writeSummary: false,
       exitProcess: true,
@@ -503,6 +511,7 @@ export class InkCLIRenderer implements CLIRenderer {
       logLevel: options.logLevel ?? "info",
       stream: options.stream ?? process.stdout,
       errorStream: options.errorStream ?? process.stderr,
+      workflowController: options.workflowController ?? getGlobalWorkflowRuntimeController(),
       ...(options.debugLogStream ? { debugLogStream: options.debugLogStream } : {})
     };
     this.columns = {
@@ -667,6 +676,35 @@ export class InkCLIRenderer implements CLIRenderer {
       );
       this.scheduleRender();
     });
+  }
+
+  private requestWorkflowCancellation(): void {
+    if (this.interruptCancellationRequested) {
+      return;
+    }
+
+    this.interruptCancellationRequested = true;
+    pushDebugLogLine(
+      this.state,
+      "[cycle:signal] Ctrl+C received, cancelling active workflow...",
+      Date.now(),
+      TIMELINE_BUFFER_SIZE
+    );
+    this.scheduleRender();
+
+    Promise.resolve(this.options.workflowController.cancelActiveRuns("Workflow cancelled by Ctrl+C."))
+      .catch((error) => {
+        pushDebugLogLine(
+          this.state,
+          `[cycle:signal] cancellation request failed: ${error instanceof Error ? error.message : String(error)}`,
+          Date.now(),
+          TIMELINE_BUFFER_SIZE
+        );
+      })
+      .finally(() => {
+        this.interruptCancellationRequested = false;
+        this.scheduleRender();
+      });
   }
 
   private scheduleRender(): void {

--- a/src/openai-provider.ts
+++ b/src/openai-provider.ts
@@ -637,6 +637,7 @@ function buildRequestOptions(request: AIChatRequest) {
     timeout?: number;
     maxRetries?: number;
     defaultBaseURL?: string;
+    signal?: AbortSignal;
   } = {};
 
   if (request.http?.headers !== undefined) {
@@ -653,6 +654,10 @@ function buildRequestOptions(request: AIChatRequest) {
 
   if (request.http?.baseURL !== undefined) {
     requestOptions.defaultBaseURL = request.http.baseURL;
+  }
+
+  if (request.http?.signal !== undefined) {
+    requestOptions.signal = request.http.signal;
   }
 
   return requestOptions;

--- a/src/runtime-control.ts
+++ b/src/runtime-control.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from "node:crypto";
+
+import { toWorkflowCancellationError } from "./errors.js";
+import type {
+  WorkflowCancellation,
+  WorkflowRuntimeController
+} from "./types.js";
+
+export class WorkflowRunControl implements WorkflowCancellation {
+  private readonly abortController = new AbortController();
+  private active = true;
+
+  get signal(): AbortSignal {
+    return this.abortController.signal;
+  }
+
+  get reason(): unknown {
+    return this.abortController.signal.reason;
+  }
+
+  isCancellationRequested(): boolean {
+    return this.abortController.signal.aborted;
+  }
+
+  throwIfRequested(): void {
+    if (!this.abortController.signal.aborted) {
+      return;
+    }
+
+    throw toWorkflowCancellationError(this.abortController.signal.reason);
+  }
+
+  cancel(reason?: unknown): boolean {
+    if (this.abortController.signal.aborted) {
+      return false;
+    }
+
+    this.abortController.abort(toWorkflowCancellationError(reason));
+    return true;
+  }
+
+  complete(): void {
+    this.active = false;
+  }
+
+  isActive(): boolean {
+    return this.active;
+  }
+}
+
+class GlobalWorkflowRuntimeController implements WorkflowRuntimeController {
+  private readonly runs = new Map<string, WorkflowRunControl>();
+
+  register(run: WorkflowRunControl): () => void {
+    const key = randomUUID();
+    this.runs.set(key, run);
+
+    return () => {
+      this.runs.delete(key);
+    };
+  }
+
+  hasActiveRuns(): boolean {
+    for (const run of this.runs.values()) {
+      if (run.isActive()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  async cancelActiveRuns(reason?: string): Promise<number> {
+    let cancelled = 0;
+    for (const run of this.runs.values()) {
+      if (!run.isActive()) {
+        continue;
+      }
+
+      if (run.cancel(reason)) {
+        cancelled += 1;
+      }
+    }
+
+    return cancelled;
+  }
+}
+
+const globalWorkflowRuntimeController = new GlobalWorkflowRuntimeController();
+
+export function getGlobalWorkflowRuntimeController(): WorkflowRuntimeController {
+  return globalWorkflowRuntimeController;
+}
+
+export function registerGlobalWorkflowRun(run: WorkflowRunControl): () => void {
+  return globalWorkflowRuntimeController.register(run);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -287,6 +287,7 @@ export type AIHTTPRequestOptions = {
   headers?: AIHTTPHeaders;
   timeoutMs?: number;
   maxRetries?: number;
+  signal?: AbortSignal;
 };
 
 export type AIHTTPDebugLoggingOptions = {
@@ -486,6 +487,18 @@ export interface TaskLogger {
   emit(event: TaskLogEvent): void;
 }
 
+export interface WorkflowCancellation {
+  signal: AbortSignal;
+  reason: unknown;
+  isCancellationRequested(): boolean;
+  throwIfRequested(): void;
+}
+
+export interface WorkflowRuntimeController {
+  hasActiveRuns(): boolean;
+  cancelActiveRuns(reason?: string): Promise<number>;
+}
+
 export type ExecutionHistorySnapshot = {
   events: ExecutionEvent[];
   taskLogs: TaskLogEvent[];
@@ -512,6 +525,7 @@ export type CLIRendererOptions = {
   maxRecentLogs?: number;
   logLevel?: TaskLogLevel;
   width?: number;
+  workflowController?: WorkflowRuntimeController;
 };
 
 export interface CLIRenderer extends ExecutionObserver {
@@ -575,6 +589,7 @@ export interface WorkflowContext {
   memoryContext?: StepMemoryContext;
   artifacts: ArtifactStore;
   log: TaskLogger;
+  cancellation: WorkflowCancellation;
   now: () => number;
   runSubWorkflow(
     key: string,
@@ -613,7 +628,7 @@ export type CycleRunResult = {
   history: ExecutionHistorySnapshot;
 };
 
-export interface Cycle {
+export interface Cycle extends WorkflowRuntimeController {
   register(key: string, workflow: WorkflowDefinition): void;
   run(key: string, input: WorkflowInput, options?: RunOptions): Promise<CycleRunResult>;
 }

--- a/tests/cycle.test.ts
+++ b/tests/cycle.test.ts
@@ -137,6 +137,89 @@ describe("Cycle foundation MVP", () => {
     );
   });
 
+  it("cancels active workflows and propagates abort signals into ctx.ai.chat()", async () => {
+    let observedSignal: AbortSignal | undefined;
+
+    class BlockingAITask extends Task {
+      name = "blockingAI";
+      memoryPhase = "EXECUTION" as const;
+      memoryTaskType = "workflow" as const;
+
+      async run(ctx: WorkflowContext): Promise<TaskResult> {
+        await ctx.ai.chat({
+          messages: [
+            {
+              role: "user",
+              content: "Block until cancellation."
+            }
+          ]
+        });
+
+        return {
+          status: "success"
+        };
+      }
+    }
+
+    const BlockingWorkflow: WorkflowDefinition = {
+      name: "blocking-workflow",
+      start: "blockingAI",
+      end: "end",
+      tasks: {
+        blockingAI: new BlockingAITask()
+      },
+      transitions: {
+        blockingAI: {
+          success: "end",
+          fail: "end"
+        }
+      }
+    };
+
+    const cycle = createCycle({
+      aiProvider: {
+        provider: "mock-ai",
+        defaultChatModel: "mock-model",
+        async chat(request) {
+          observedSignal = request.http?.signal;
+          return await new Promise((_resolve, reject) => {
+            request.http?.signal?.addEventListener(
+              "abort",
+              () => {
+                reject(request.http?.signal?.reason);
+              },
+              { once: true }
+            );
+          });
+        },
+        async chatStream() {
+          throw new Error("chatStream should not be used in this test");
+        }
+      }
+    });
+    cycle.register("blocking-workflow", BlockingWorkflow);
+
+    const runPromise = cycle.run("blocking-workflow", createWorkflowInput());
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(cycle.hasActiveRuns()).toBe(true);
+
+    const cancelled = await cycle.cancelActiveRuns("Workflow cancelled by Ctrl+C.");
+    const result = await runPromise;
+
+    expect(cancelled).toBe(1);
+    expect(observedSignal?.aborted).toBe(true);
+    expect(result.frame.status).toBe("fail");
+    expect(result.frame.errors).toContain("Workflow cancelled by Ctrl+C.");
+    expect(result.frame.taskResults.blockingAI?.error).toEqual(
+      expect.objectContaining({
+        message: "Workflow cancelled by Ctrl+C.",
+        code: "ABORTED"
+      })
+    );
+    expect(cycle.hasActiveRuns()).toBe(false);
+  });
+
   it("applies automatic memory hooks and bootstraps memoryInjection plus rag records", async () => {
     class CaptureUserContextTask extends Task {
       name = "captureUser";

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -275,7 +275,11 @@ describe("CLI renderer", () => {
       mode: "ink",
       persistAfterCompletion: true,
       stream: ttyLike,
-      errorStream: ttyLike
+      errorStream: ttyLike,
+      workflowController: {
+        hasActiveRuns: () => false,
+        cancelActiveRuns: async () => 0
+      }
     }) as InkCLIRenderer & Record<string, unknown>;
 
     let leaveCalls = 0;
@@ -310,5 +314,71 @@ describe("CLI renderer", () => {
     expect(leaveCalls).toBe(1);
     expect(summaryCalls).toBe(0);
     expect(exitCode).toBe(0);
+  });
+
+  it("handles Ctrl+C by cancelling active workflows before exiting", async () => {
+    const ttyLike = stream as unknown as NodeJS.WriteStream & {
+      isTTY?: boolean;
+      columns?: number;
+      rows?: number;
+      on?: typeof stream.on;
+      off?: typeof stream.off;
+    };
+    ttyLike.isTTY = true;
+    ttyLike.columns = 100;
+    ttyLike.rows = 30;
+    ttyLike.on = ((..._args: Parameters<typeof stream.on>) => ttyLike) as typeof ttyLike.on;
+    ttyLike.off = ((..._args: Parameters<typeof stream.off>) => ttyLike) as typeof ttyLike.off;
+
+    let cancelCalls = 0;
+    let leaveCalls = 0;
+    let summaryCalls = 0;
+    let exitCode: number | undefined;
+
+    const renderer = new InkCLIRenderer({
+      enabled: true,
+      mode: "ink",
+      persistAfterCompletion: true,
+      stream: ttyLike,
+      errorStream: ttyLike,
+      workflowController: {
+        hasActiveRuns: () => true,
+        cancelActiveRuns: async () => {
+          cancelCalls += 1;
+          return 1;
+        }
+      }
+    }) as InkCLIRenderer & Record<string, unknown>;
+
+    renderer["attachResizeHandler"] = () => undefined;
+    renderer["attachDebugStream"] = () => undefined;
+    renderer["renderNow"] = () => undefined;
+    renderer["enterAlternateScreen"] = () => undefined;
+    renderer["leaveAlternateScreen"] = () => {
+      leaveCalls += 1;
+    };
+    renderer["writeFinalSummary"] = () => {
+      summaryCalls += 1;
+    };
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      return undefined as never;
+    }) as typeof process.exit;
+
+    try {
+      renderer.start();
+      const signalHandler = renderer["processSignalHandler"] as (() => void) | undefined;
+      signalHandler?.();
+      await Promise.resolve();
+    } finally {
+      process.exit = originalExit;
+    }
+
+    expect(cancelCalls).toBe(1);
+    expect(leaveCalls).toBe(0);
+    expect(summaryCalls).toBe(0);
+    expect(exitCode).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary
- add workflow runtime cancellation control and propagate abort signals into task context and AI requests
- update Ink Ctrl+C handling to cancel active workflows before exiting idle sessions
- add runtime and renderer regression coverage plus README updates

## Testing
- npm run typecheck
- npm test
- npm run build
- npm --prefix sample-project run typecheck
- npm --prefix sample-project run start:sub:line