### PR TITLE
[codex] ci: add npm publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,88 @@
+name: Publish npm package
+
+on:
+  workflow_dispatch:
+    inputs:
+      npm_tag:
+        description: npm dist-tag to publish with
+        required: false
+        default: latest
+        type: string
+      dry_run:
+        description: Build and validate the publish payload without uploading to npm
+        required: false
+        default: false
+        type: boolean
+  push:
+    tags:
+      - "v*"
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+          cache: "npm"
+
+      - name: Guard manual publish branch
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        run: |
+          if [ "${GITHUB_REF_NAME}" != "${{ github.event.repository.default_branch }}" ]; then
+            echo "Manual publish is only allowed from the default branch."
+            echo "Current ref: ${GITHUB_REF_NAME}"
+            echo "Default branch: ${{ github.event.repository.default_branch }}"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Typecheck
+        run: npm run typecheck
+
+      - name: Test
+        run: npm test
+
+      - name: Build all-in-one publish artifact
+        run: npm run build:all-in-one
+
+      - name: Verify packed artifact
+        run: npm pack ./.npm-package
+
+      - name: Verify tag matches package version
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: |
+          node -e 'const fs=require("node:fs"); const pkg=JSON.parse(fs.readFileSync("package.json","utf8")); const tag=process.env.GITHUB_REF_NAME; const expected=`v${pkg.version}`; if(tag!==expected){console.error(`Git tag ${tag} does not match package version ${pkg.version}`); process.exit(1);} console.log(`Verified ${tag} matches package version ${pkg.version}`);'
+
+      - name: Dry-run npm publish
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run == 'true'
+        run: npm publish ./.npm-package --access public --dry-run --tag "${{ github.event.inputs.npm_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Publish to npm from workflow dispatch
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        run: npm publish ./.npm-package --access public --tag "${{ github.event.inputs.npm_tag }}"
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Publish to npm from tag push
+        if: startsWith(github.ref, 'refs/tags/v')
+        run: npm publish ./.npm-package --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -298,6 +298,8 @@ npm run publish:all-in-one:dry-run
 
 이 스크립트는 `.npm-package/` 아래에 runtime dependency 없는 publish 전용 package manifest 와 `dist/` 번들을 만든다.
 
+GitHub Actions 에서는 `.github/workflows/npm-publish.yml` 이 같은 publish 경로를 사용한다. repository secret `NPM_AUTH_TOKEN` 을 등록하면 `workflow_dispatch` 또는 `v*` tag push 로 publish 할 수 있다. manual publish 는 default branch 에서만 허용된다.
+
 ## 문서
 - [developer guide](https://github.com/skyend/agentic-task-kit/blob/main/docs/developer-guide.md)
 - [memory guide](https://github.com/skyend/agentic-task-kit/blob/main/docs/memory-guide.md)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -273,6 +273,24 @@ npm run publish:all-in-one:dry-run
 npm run publish:all-in-one
 ```
 
+## GitHub Actions publish automation
+repository secret `NPM_AUTH_TOKEN` 을 등록하면 `.github/workflows/npm-publish.yml` 로 같은 all-in-one artifact 를 GitHub Actions 에서 publish 할 수 있다.
+
+- trigger:
+  - `workflow_dispatch`
+  - `v*` tag push
+- gate:
+  - `npm ci`
+  - `npm run typecheck`
+  - `npm test`
+  - `npm run build:all-in-one`
+  - `npm pack ./.npm-package`
+- 인증:
+  - workflow 는 `secrets.NPM_AUTH_TOKEN` 을 `NODE_AUTH_TOKEN` 으로 매핑해 npm registry 인증에 사용한다.
+- 안전장치:
+  - manual publish 는 default branch 에서만 허용된다.
+  - tag publish 는 `v${package.json.version}` 일치 여부를 검사한다.
+
 ## AI task 에 memory context 넣기
 memory 조회는 자동이지만, AI 프롬프트 주입은 task 코드가 직접 한다.
 


### PR DESCRIPTION
## Summary\n- add a GitHub Actions workflow to publish the all-in-one npm artifact\n- require typecheck, test, build, and pack validation before publish\n- wire npm auth through the NPM_AUTH_TOKEN repository secret\n\n## Validation\n- ruby YAML parse\n- npm ci\n- npm run typecheck\n- npm test\n- npm run build:all-in-one\n- npm run publish:all-in-one:dry-run