### PR TITLE
[codex] ci: auto bump version before publish

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,6 +3,11 @@ name: Publish npm package
 on:
   workflow_dispatch:
     inputs:
+      version_bump:
+        description: Version bump type for release publish
+        required: false
+        default: patch
+        type: string
       npm_tag:
         description: npm dist-tag to publish with
         required: false
@@ -23,9 +28,10 @@ concurrency:
 
 jobs:
   publish:
+    if: github.event_name != 'push' || github.actor != 'github-actions[bot]'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -58,6 +64,17 @@ jobs:
       - name: Test
         run: npm test
 
+      - name: Configure release git author
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Prepare release version
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        id: release_version
+        run: npm run release:prepare-version -- "${{ github.event.inputs.version_bump }}"
+
       - name: Build all-in-one publish artifact
         run: npm run build:all-in-one
 
@@ -80,6 +97,19 @@ jobs:
         run: npm publish ./.npm-package --access public --tag "${{ github.event.inputs.npm_tag }}"
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
+
+      - name: Persist release commit and tag
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.dry_run != 'true'
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.version }}
+          RELEASE_TAG: ${{ steps.release_version.outputs.tag }}
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          git add package.json package-lock.json
+          git commit -m "chore(release): ${RELEASE_TAG}"
+          git tag "${RELEASE_TAG}"
+          git push origin "HEAD:${DEFAULT_BRANCH}"
+          git push origin "${RELEASE_TAG}"
 
       - name: Publish to npm from tag push
         if: startsWith(github.ref, 'refs/tags/v')

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ npm run publish:all-in-one:dry-run
 
 이 스크립트는 `.npm-package/` 아래에 runtime dependency 없는 publish 전용 package manifest 와 `dist/` 번들을 만든다.
 
-GitHub Actions 에서는 `.github/workflows/npm-publish.yml` 이 같은 publish 경로를 사용한다. repository secret `NPM_AUTH_TOKEN` 을 등록하면 `workflow_dispatch` 또는 `v*` tag push 로 publish 할 수 있다. manual publish 는 default branch 에서만 허용된다.
+GitHub Actions 에서는 `.github/workflows/npm-publish.yml` 이 같은 publish 경로를 사용한다. repository secret `NPM_AUTH_TOKEN` 을 등록하면 `workflow_dispatch` 또는 `v*` tag push 로 publish 할 수 있다. manual publish 는 default branch 에서만 허용되고, 기본 `patch` version bump 후 publish 한 다음 release commit 과 `v<version>` tag 를 origin 에 반영한다.
 
 ## 문서
 - [developer guide](https://github.com/skyend/agentic-task-kit/blob/main/docs/developer-guide.md)

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -279,6 +279,9 @@ repository secret `NPM_AUTH_TOKEN` 을 등록하면 `.github/workflows/npm-publi
 - trigger:
   - `workflow_dispatch`
   - `v*` tag push
+- versioning:
+  - `workflow_dispatch` publish 는 `version_bump` 입력을 받고 기본값은 `patch` 다.
+  - publish 전 `package.json` / `package-lock.json` version 을 올리고, 성공 후 release commit 과 `v<version>` tag 를 origin 에 push 한다.
 - gate:
   - `npm ci`
   - `npm run typecheck`
@@ -290,6 +293,7 @@ repository secret `NPM_AUTH_TOKEN` 을 등록하면 `.github/workflows/npm-publi
 - 안전장치:
   - manual publish 는 default branch 에서만 허용된다.
   - tag publish 는 `v${package.json.version}` 일치 여부를 검사한다.
+  - `github-actions[bot]` 가 만든 tag push run 은 중복 publish 를 피하기 위해 skip 한다.
 
 ## AI task 에 memory context 넣기
 memory 조회는 자동이지만, AI 프롬프트 주입은 task 코드가 직접 한다.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "build:types": "tsc -p tsconfig.build.json --emitDeclarationOnly",
     "build:bundle": "node ./scripts/build-package.mjs",
     "build:all-in-one": "npm run build && node ./scripts/build-all-in-one-package.mjs",
+    "release:prepare-version": "node ./scripts/prepare-release-version.mjs",
     "pack:all-in-one": "npm run build:all-in-one && npm pack ./.npm-package",
     "publish:all-in-one": "npm run build:all-in-one && npm publish ./.npm-package --access public",
     "publish:all-in-one:dry-run": "npm run build:all-in-one && npm publish ./.npm-package --access public --dry-run",

--- a/scripts/prepare-release-version.mjs
+++ b/scripts/prepare-release-version.mjs
@@ -1,0 +1,63 @@
+import { execFileSync } from "node:child_process";
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const projectRoot = resolve(import.meta.dirname, "..");
+const packageJsonPath = resolve(projectRoot, "package.json");
+const packageLockPath = resolve(projectRoot, "package-lock.json");
+const allowedBumps = new Set([
+  "patch",
+  "minor",
+  "major",
+  "prepatch",
+  "preminor",
+  "premajor",
+  "prerelease"
+]);
+
+function readPackageVersion(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8")).version;
+}
+
+function writeOutput(name, value) {
+  if (process.env.GITHUB_OUTPUT) {
+    writeFileSync(process.env.GITHUB_OUTPUT, `${name}=${value}\n`, {
+      encoding: "utf8",
+      flag: "a"
+    });
+  }
+}
+
+const bumpType = process.argv[2] ?? "patch";
+
+if (!allowedBumps.has(bumpType)) {
+  throw new Error(
+    `Unsupported version bump type: ${bumpType}. Expected one of ${Array.from(allowedBumps).join(", ")}.`
+  );
+}
+
+const previousVersion = readPackageVersion(packageJsonPath);
+
+execFileSync("npm", ["version", bumpType, "--no-git-tag-version"], {
+  cwd: projectRoot,
+  stdio: "inherit"
+});
+
+const nextVersion = readPackageVersion(packageJsonPath);
+const packageLockVersion = readPackageVersion(packageLockPath);
+
+if (packageLockVersion !== nextVersion) {
+  throw new Error(
+    `package-lock.json version mismatch after bump. package.json=${nextVersion}, package-lock.json=${packageLockVersion}`
+  );
+}
+
+const releaseTag = `v${nextVersion}`;
+
+writeOutput("previous_version", previousVersion);
+writeOutput("version", nextVersion);
+writeOutput("tag", releaseTag);
+
+process.stdout.write(
+  `Prepared release version bump: ${previousVersion} -> ${nextVersion} (${releaseTag})\n`
+);


### PR DESCRIPTION
## Summary\n- inspect the failed npm publish action and confirm the root cause was republishing version 0.1.1\n- add automatic version bumping for workflow_dispatch publishes before building the release artifact\n- persist the bumped package version back to the repo with a release commit and tag after a successful publish\n\n## Validation\n- gh run view 24032834093 --log\n- ruby YAML parse\n- npm ci\n- npm run typecheck\n- npm test\n- npm run build:all-in-one\n- npm run publish:all-in-one:dry-run\n- temp-dir prepare-release-version.mjs patch smoke test