### PR TITLE
[codex] build: exclude source maps from publish artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ npm run build:all-in-one
 npm run publish:all-in-one:dry-run
 ```
 
-이 스크립트는 `.npm-package/` 아래에 runtime dependency 없는 publish 전용 package manifest 와 `dist/` 번들을 만든다.
+이 스크립트는 `.npm-package/` 아래에 runtime dependency 없는 publish 전용 package manifest 와 `dist/` 번들을 만든다. publish artifact 에는 `dist/**/*.map` source map 을 포함하지 않는다.
 
 GitHub Actions 에서는 `.github/workflows/npm-publish.yml` 이 같은 publish 경로를 사용한다. repository secret `NPM_AUTH_TOKEN` 을 등록하면 `workflow_dispatch` 또는 `v*` tag push 로 publish 할 수 있다. manual publish 는 default branch 에서만 허용되고, 기본 `patch` version bump 후 publish 한 다음 release commit 과 `v<version>` tag 를 origin 에 반영한다.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -260,7 +260,7 @@ const cycle = createCycle({
 provider 문서는 [openai-chat-api.md](./openai-chat-api.md) 를 본다.
 
 ## All-in-one npm 패키지 빌드
-배포용으로는 runtime dependency 를 비운 publish artifact 를 `.npm-package/` 아래에 만든다.
+배포용으로는 runtime dependency 를 비운 publish artifact 를 `.npm-package/` 아래에 만든다. publish artifact 에는 `dist/**/*.map` source map 을 싣지 않는다.
 
 ```bash
 npm run build:all-in-one

--- a/docs/release-guide.md
+++ b/docs/release-guide.md
@@ -7,7 +7,7 @@
 - npm registry publish 권한이 있는 `NPM_AUTH_TOKEN` repository secret 이 설정되어 있어야 한다.
 - default branch 는 `main` 이어야 한다.
 - `package.json` 과 `package-lock.json` 은 workflow 가 자동으로 version bump 한다.
-- publish artifact 는 `.npm-package/` all-in-one bundle 이다.
+- publish artifact 는 `.npm-package/` all-in-one bundle 이고, `dist/**/*.map` source map 은 제외된다.
 
 ## 권장 릴리스 경로
 가장 권장되는 경로는 GitHub Actions `workflow_dispatch` 다.
@@ -68,6 +68,7 @@ dry-run 에서는:
 - all-in-one bundle build
 - `npm pack`
 - `npm publish --dry-run`
+- tarball contents 에 `.map` 파일이 없는지 확인
 
 ## 로컬 검증 명령
 GitHub Actions 를 돌리기 전에 로컬에서 확인하려면:

--- a/scripts/build-all-in-one-package.mjs
+++ b/scripts/build-all-in-one-package.mjs
@@ -54,7 +54,10 @@ async function main() {
 
   await rm(outputDir, { recursive: true, force: true });
   await mkdir(outputDir, { recursive: true });
-  await cp(distDir, resolve(outputDir, "dist"), { recursive: true });
+  await cp(distDir, resolve(outputDir, "dist"), {
+    recursive: true,
+    filter: (source) => !source.endsWith(".map")
+  });
   await copyFile(readmePath, resolve(outputDir, "README.md"));
   await copyFile(licensePath, resolve(outputDir, "LICENSE"));
 


### PR DESCRIPTION
## Summary\n- exclude dist source maps from the all-in-one publish artifact\n- document that release payloads omit .map files in the README and release docs\n- keep local dist sourcemaps intact while shrinking the published tarball\n\n## Validation\n- npm ci\n- npm run build:all-in-one\n- find .npm-package/dist -name '*.map'\n- npm run publish:all-in-one:dry-run\n- verify dry-run tarball contents contain no .map files