### PR TITLE
[codex] align package metadata and publish 0.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -296,7 +296,7 @@ npm run build:all-in-one
 npm run publish:all-in-one:dry-run
 ```
 
-이 스크립트는 `.npm-package/` 아래에 runtime dependency 없는 publish 전용 package manifest 와 `dist/` 번들을 만든다. publish artifact 에는 `dist/**/*.map` source map 을 포함하지 않는다.
+이 스크립트는 `.npm-package/` 아래에 runtime dependency 없는 publish 전용 package manifest 와 `dist/` 번들을 만들고, publish artifact 에서는 `dist/**/*.map` source map 파일을 제외한다.
 
 GitHub Actions 에서는 `.github/workflows/npm-publish.yml` 이 같은 publish 경로를 사용한다. repository secret `NPM_AUTH_TOKEN` 을 등록하면 `workflow_dispatch` 또는 `v*` tag push 로 publish 할 수 있다. manual publish 는 default branch 에서만 허용되고, 기본 `patch` version bump 후 publish 한 다음 release commit 과 `v<version>` tag 를 origin 에 반영한다.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -260,7 +260,7 @@ const cycle = createCycle({
 provider 문서는 [openai-chat-api.md](./openai-chat-api.md) 를 본다.
 
 ## All-in-one npm 패키지 빌드
-배포용으로는 runtime dependency 를 비운 publish artifact 를 `.npm-package/` 아래에 만든다. publish artifact 에는 `dist/**/*.map` source map 을 싣지 않는다.
+배포용으로는 runtime dependency 를 비운 publish artifact 를 `.npm-package/` 아래에 만들고, `dist/**/*.map` source map 파일은 포함하지 않는다.
 
 ```bash
 npm run build:all-in-one

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agentic-task-kit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agentic-task-kit",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.5.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentic-task-kit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Cycle foundation MVP for implementing AX Workflow in Node.js and TypeScript.",
   "type": "module",
   "repository": {


### PR DESCRIPTION
## Summary
- align package repository/homepage/bugs metadata with the moved origin
- exclude source maps from the all-in-one npm publish artifact
- bump to 0.1.2 and publish the package locally

## Verification
- npm ci
- npm run typecheck
- npm test
- npm run build:all-in-one
- npm run publish:all-in-one:dry-run
- npm run publish:all-in-one
- npm view agentic-task-kit version dist-tags.latest --json