### PR TITLE
fix: handle raw ctrl-c in ink mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_REN
 - line mode 는 warning/error task log meta 를 `...` 없이 전체 출력
 - workflow 실행 중 `Ctrl+C`: 현재 active workflow 와 sub-workflow 에 graceful cancel signal 전파 후, run 종료 시 Ink terminal reset + 프로세스 종료
 - idle 상태 `Ctrl+C`: 즉시 Ink terminal reset 후 프로세스 종료
+- 위 `Ctrl+C` 동작은 process `SIGINT` 와 Ink raw input 경로 양쪽에서 동일하게 적용된다
 
 interactive TTY 가 아니면 `ink` 모드는 `jsonl` 로 자동 fallback 된다.
 

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -39,7 +39,7 @@ CYCLE_LIVE=0 npm run example
 
 Ink mode 에서는 좌측에 workflow/task history, 우측에 task log + provider debug log 가 2컬럼으로 출력된다.
 `Tab`, `↑↓`, `j k`, `PageUp/PageDown`, `Home/End`, `g/G` 를 지원한다.
-workflow 실행 중 `Ctrl+C` 는 active workflow graceful cancel 을 요청하고, run 종료가 관측되면 terminal reset + exit 를 수행한다. idle 상태에서는 즉시 terminal reset + exit 를 수행한다.
+workflow 실행 중 `Ctrl+C` 는 active workflow graceful cancel 을 요청하고, run 종료가 관측되면 terminal reset + exit 를 수행한다. idle 상태에서는 즉시 terminal reset + exit 를 수행한다. 이 정책은 process `SIGINT` 와 Ink raw input 경로 모두에 동일하게 적용된다.
 TTY 가 아니면 `jsonl` 로 fallback 된다.
 
 ## Bundle build

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -134,4 +134,4 @@ OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_REN
 - child workflow: `service-analysis`
 - branch id: `branch.service-analysis`
 
-Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행 중 `Ctrl+C` 를 누르면 현재 active workflow 와 child workflow 에 graceful cancel signal 이 먼저 전달되고, run 종료가 관측되는 즉시 Ink session 이 닫히고 프로세스가 종료된다.
+Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행 중 `Ctrl+C` 를 누르면 현재 active workflow 와 child workflow 에 graceful cancel signal 이 먼저 전달되고, run 종료가 관측되는 즉시 Ink session 이 닫히고 프로세스가 종료된다. 이 경로는 raw terminal input `Ctrl+C` 도 포함한다.

--- a/src/ink-renderer.tsx
+++ b/src/ink-renderer.tsx
@@ -61,6 +61,7 @@ type InkRendererScreenProps = {
   finalStatus: "success" | "fail" | undefined;
   useColor: boolean;
   colorTheme: ResolvedTaskLogColorTheme;
+  onInterrupt?: () => void;
 };
 
 const DEFAULT_COLUMNS = 100;
@@ -70,6 +71,19 @@ const RIGHT_MIN_WIDTH = 42;
 const HISTORY_BUFFER_SIZE = 240;
 const TIMELINE_BUFFER_SIZE = 480;
 const TASK_BOX_INNER_WIDTH = 16;
+
+type InkInputKey = {
+  ctrl?: boolean;
+  name?: string;
+  sequence?: string;
+  tab?: boolean;
+  upArrow?: boolean;
+  downArrow?: boolean;
+  pageUp?: boolean;
+  pageDown?: boolean;
+  home?: boolean;
+  end?: boolean;
+};
 
 function clamp(value: number, min: number, max: number): number {
   return Math.min(max, Math.max(min, value));
@@ -368,13 +382,22 @@ export function reduceInkUIState(
   }
 }
 
+export function isInkInterruptInput(input: string, key: InkInputKey): boolean {
+  if (input === "\u0003" || key.sequence === "\u0003") {
+    return true;
+  }
+
+  return key.ctrl === true && (input.toLowerCase() === "c" || key.name === "c");
+}
+
 export function InkRendererScreen({
   state,
   columns,
   rows,
   finalStatus,
   useColor,
-  colorTheme
+  colorTheme,
+  onInterrupt
 }: InkRendererScreenProps): ReactElement {
   const [uiState, setUiState] = useState<InkUIState>({
     focusedPane: "right",
@@ -413,6 +436,11 @@ export function InkRendererScreen({
   }, [metrics.leftMaxScroll, metrics.rightMaxScroll, metrics.pageSize]);
 
   useInput((input, key) => {
+    if (isInkInterruptInput(input, key)) {
+      onInterrupt?.();
+      return;
+    }
+
     if (key.tab || input === "\t") {
       setUiState((current) => reduceInkUIState(current, { type: "focus.toggle" }, metrics));
       return;
@@ -804,6 +832,9 @@ export class InkCLIRenderer implements CLIRenderer {
         finalStatus={this.finalStatus.value}
         useColor={this.options.useColor}
         colorTheme={this.options.colorTheme}
+        onInterrupt={() => {
+          this.processSignalHandler();
+        }}
       />
     );
 

--- a/tests/ink-renderer.test.tsx
+++ b/tests/ink-renderer.test.tsx
@@ -4,6 +4,7 @@ import { describe, expect, it } from "vitest";
 import { DEFAULT_TASK_LOG_COLOR_THEME } from "../src/renderer-colors.js";
 import {
   InkRendererScreen,
+  isInkInterruptInput,
   reduceInkUIState,
   type InkUIState
 } from "../src/ink-renderer.js";
@@ -170,6 +171,13 @@ function createInkState(): RendererState {
 }
 
 describe("Ink renderer screen", () => {
+  it("detects Ctrl+C in raw input and control-key forms", () => {
+    expect(isInkInterruptInput("\u0003", {})).toBe(true);
+    expect(isInkInterruptInput("c", { ctrl: true, name: "c" })).toBe(true);
+    expect(isInkInterruptInput("C", { ctrl: true, name: "c" })).toBe(true);
+    expect(isInkInterruptInput("c", { ctrl: false, name: "c" })).toBe(false);
+  });
+
   it("renders workflow flowchart, branch nesting, task durations, and logs", async () => {
     const state = createInkState();
     const instance = render(
@@ -242,6 +250,32 @@ describe("Ink renderer screen", () => {
       await flushInk();
       expect(instance.lastFrame()).toContain("follow=on");
       expect(instance.lastFrame()).toContain("[REQ] gemini POST");
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it("invokes the interrupt callback when raw Ctrl+C input is received", async () => {
+    const state = createInkState();
+    let interrupted = 0;
+    const instance = render(
+      <InkRendererScreen
+        state={state}
+        columns={110}
+        rows={18}
+        finalStatus={undefined}
+        useColor={false}
+        colorTheme={DEFAULT_TASK_LOG_COLOR_THEME}
+        onInterrupt={() => {
+          interrupted += 1;
+        }}
+      />
+    );
+
+    try {
+      instance.stdin.write("\u0003");
+      await flushInk();
+      expect(interrupted).toBe(1);
     } finally {
       instance.unmount();
     }


### PR DESCRIPTION
## Summary\n- handle Ink raw-input Ctrl+C through the same graceful shutdown path as SIGINT\n- add a raw-input interrupt helper and screen-level callback wiring\n- document the raw-input parity in the README and sample docs\n\n## Testing\n- npm run typecheck\n- npm test\n- sample-project: npm run start:sub:ink, then send raw Ctrl+C in a TTY session and verify exit