### PR TITLE
feat: add ink quit key

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_REN
 - `↑↓` / `j k`: 현재 패널 스크롤
 - `PageUp/PageDown`: 페이지 단위 스크롤
 - `Home/End`, `g/G`: 처음/끝 이동
+- `q`: Ink 종료. active workflow 가 있으면 graceful cancel 후 종료, idle 이면 즉시 종료
 - `CYCLE_LOG_LEVEL=debug`: task debug log 와 provider HTTP debug log 노출
 - line mode 는 warning/error task log meta 를 `...` 없이 전체 출력
 - workflow 실행 중 `Ctrl+C`: 현재 active workflow 와 sub-workflow 에 graceful cancel signal 전파 후, run 종료 시 Ink terminal reset + 프로세스 종료
@@ -255,7 +256,7 @@ await cycle.run("report", input);
 ```
 
 ## Workflow Cancellation
-`WorkflowContext.cancellation.signal` 로 현재 workflow run 의 cancel signal 을 읽을 수 있다. `ink` mode 에서는 `Ctrl+C` 가 active workflow 를 먼저 graceful cancel 하고, run 종료가 관측되면 terminal reset + exit 를 수행한다. active workflow 가 없으면 즉시 terminal reset + exit 한다.
+`WorkflowContext.cancellation.signal` 로 현재 workflow run 의 cancel signal 을 읽을 수 있다. `ink` mode 에서는 `Ctrl+C` 가 active workflow 를 먼저 graceful cancel 하고, run 종료가 관측되면 terminal reset + exit 를 수행한다. active workflow 가 없으면 즉시 terminal reset + exit 한다. 명시적인 종료 키 `q` 도 같은 정책을 따르며, 종료 code 는 정상 종료로 처리한다.
 
 ```ts
 class LongTask extends Task {

--- a/docs/local-setup.md
+++ b/docs/local-setup.md
@@ -38,8 +38,8 @@ CYCLE_LIVE=0 npm run example
 ```
 
 Ink mode 에서는 좌측에 workflow/task history, 우측에 task log + provider debug log 가 2컬럼으로 출력된다.
-`Tab`, `↑↓`, `j k`, `PageUp/PageDown`, `Home/End`, `g/G` 를 지원한다.
-workflow 실행 중 `Ctrl+C` 는 active workflow graceful cancel 을 요청하고, run 종료가 관측되면 terminal reset + exit 를 수행한다. idle 상태에서는 즉시 terminal reset + exit 를 수행한다. 이 정책은 process `SIGINT` 와 Ink raw input 경로 모두에 동일하게 적용된다.
+`Tab`, `↑↓`, `j k`, `PageUp/PageDown`, `Home/End`, `g/G`, `q` 를 지원한다.
+workflow 실행 중 `Ctrl+C` 는 active workflow graceful cancel 을 요청하고, run 종료가 관측되면 terminal reset + exit 를 수행한다. idle 상태에서는 즉시 terminal reset + exit 를 수행한다. 이 정책은 process `SIGINT` 와 Ink raw input 경로 모두에 동일하게 적용된다. `q` 는 명시적인 종료 키이며, active workflow 가 있으면 graceful cancel 후 종료하고 idle 상태에서는 즉시 종료한다.
 TTY 가 아니면 `jsonl` 로 fallback 된다.
 
 ## Bundle build

--- a/sample-project/README.md
+++ b/sample-project/README.md
@@ -134,4 +134,4 @@ OPENAI_API_KEY=your_key_here OPENAI_HTTP_DEBUG=1 CYCLE_LOG_LEVEL=debug CYCLE_REN
 - child workflow: `service-analysis`
 - branch id: `branch.service-analysis`
 
-Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행 중 `Ctrl+C` 를 누르면 현재 active workflow 와 child workflow 에 graceful cancel signal 이 먼저 전달되고, run 종료가 관측되는 즉시 Ink session 이 닫히고 프로세스가 종료된다. 이 경로는 raw terminal input `Ctrl+C` 도 포함한다.
+Ink mode 에서는 parent 아래에 child workflow branch 가 이어서 렌더링되고, 각 task box 에 task 이름과 소요시간이 함께 표시된다. workflow 실행 중 `Ctrl+C` 를 누르면 현재 active workflow 와 child workflow 에 graceful cancel signal 이 먼저 전달되고, run 종료가 관측되는 즉시 Ink session 이 닫히고 프로세스가 종료된다. 이 경로는 raw terminal input `Ctrl+C` 도 포함한다. 명시적인 종료 키 `q` 도 제공되며, active workflow 가 있으면 graceful cancel 후 종료하고 idle 상태면 즉시 종료한다.

--- a/src/ink-renderer.tsx
+++ b/src/ink-renderer.tsx
@@ -62,6 +62,7 @@ type InkRendererScreenProps = {
   useColor: boolean;
   colorTheme: ResolvedTaskLogColorTheme;
   onInterrupt?: () => void;
+  onQuit?: () => void;
 };
 
 const DEFAULT_COLUMNS = 100;
@@ -74,6 +75,7 @@ const TASK_BOX_INNER_WIDTH = 16;
 
 type InkInputKey = {
   ctrl?: boolean;
+  meta?: boolean;
   name?: string;
   sequence?: string;
   tab?: boolean;
@@ -113,7 +115,7 @@ function buildHeaderLine(state: RendererState, columns: number): string {
 
 function buildFooterLine(columns: number, focusedPane: InkPane, rightAutoFollow: boolean): string {
   const text =
-    `Tab pane  up/down,j/k scroll  PgUp/PgDn page  Home/End,g/G edge  focus=${focusedPane}  follow=${rightAutoFollow ? "on" : "off"}`;
+    `Tab pane  up/down,j/k scroll  PgUp/PgDn page  Home/End,g/G edge  q quit  focus=${focusedPane}  follow=${rightAutoFollow ? "on" : "off"}`;
   return padLine(text, columns);
 }
 
@@ -390,6 +392,14 @@ export function isInkInterruptInput(input: string, key: InkInputKey): boolean {
   return key.ctrl === true && (input.toLowerCase() === "c" || key.name === "c");
 }
 
+export function isInkQuitInput(input: string, key: InkInputKey): boolean {
+  if (key.ctrl === true || key.meta === true) {
+    return false;
+  }
+
+  return input.toLowerCase() === "q";
+}
+
 export function InkRendererScreen({
   state,
   columns,
@@ -397,7 +407,8 @@ export function InkRendererScreen({
   finalStatus,
   useColor,
   colorTheme,
-  onInterrupt
+  onInterrupt,
+  onQuit
 }: InkRendererScreenProps): ReactElement {
   const [uiState, setUiState] = useState<InkUIState>({
     focusedPane: "right",
@@ -438,6 +449,11 @@ export function InkRendererScreen({
   useInput((input, key) => {
     if (isInkInterruptInput(input, key)) {
       onInterrupt?.();
+      return;
+    }
+
+    if (isInkQuitInput(input, key)) {
+      onQuit?.();
       return;
     }
 
@@ -564,10 +580,32 @@ export class InkCLIRenderer implements CLIRenderer {
   private debugLineReader: ReadLineInterface | null = null;
   private resizeHandler: (() => void) | null = null;
   private interruptCancellationRequested = false;
-  private exitAfterWorkflowCancellation = false;
+  private exitAfterWorkflowCancellation: number | null = null;
   private readonly processSignalHandler = (): void => {
     if (this.options.workflowController.hasActiveRuns()) {
-      this.requestWorkflowCancellation();
+      this.requestWorkflowCancellation({
+        reason: "Workflow cancelled by Ctrl+C.",
+        message:
+          "[cycle:signal] Ctrl+C received, cancelling active workflow and exiting when the run stops...",
+        exitCode: InkCLIRenderer.SIGNAL_EXIT_CODE
+      });
+      return;
+    }
+
+    this.shutdown({
+      writeSummary: false,
+      exitProcess: true,
+      exitCode: 0
+    });
+  };
+  private readonly processQuitHandler = (): void => {
+    if (this.options.workflowController.hasActiveRuns()) {
+      this.requestWorkflowCancellation({
+        reason: "Workflow cancelled by quit key.",
+        message:
+          "[cycle:signal] q received, cancelling active workflow and exiting when the run stops...",
+        exitCode: 0
+      });
       return;
     }
 
@@ -626,11 +664,11 @@ export class InkCLIRenderer implements CLIRenderer {
     this.finalStatus.value = finalStatus;
     this.renderNow();
 
-    if (this.exitAfterWorkflowCancellation) {
+    if (this.exitAfterWorkflowCancellation !== null) {
       this.shutdown({
         writeSummary: true,
         exitProcess: true,
-        exitCode: InkCLIRenderer.SIGNAL_EXIT_CODE
+        exitCode: this.exitAfterWorkflowCancellation
       });
       return;
     }
@@ -678,7 +716,7 @@ export class InkCLIRenderer implements CLIRenderer {
     this.inkInstance = null;
     this.leaveAlternateScreen();
     this.started = false;
-    this.exitAfterWorkflowCancellation = false;
+    this.exitAfterWorkflowCancellation = null;
     this.interruptCancellationRequested = false;
 
     if (args.writeSummary) {
@@ -769,22 +807,26 @@ export class InkCLIRenderer implements CLIRenderer {
     });
   }
 
-  private requestWorkflowCancellation(): void {
+  private requestWorkflowCancellation(args: {
+    reason: string;
+    message: string;
+    exitCode: number;
+  }): void {
     if (this.interruptCancellationRequested) {
       return;
     }
 
     this.interruptCancellationRequested = true;
-    this.exitAfterWorkflowCancellation = true;
+    this.exitAfterWorkflowCancellation = args.exitCode;
     pushDebugLogLine(
       this.state,
-      "[cycle:signal] Ctrl+C received, cancelling active workflow and exiting when the run stops...",
+      args.message,
       Date.now(),
       TIMELINE_BUFFER_SIZE
     );
     this.scheduleRender();
 
-    Promise.resolve(this.options.workflowController.cancelActiveRuns("Workflow cancelled by Ctrl+C."))
+    Promise.resolve(this.options.workflowController.cancelActiveRuns(args.reason))
       .catch((error) => {
         pushDebugLogLine(
           this.state,
@@ -830,12 +872,15 @@ export class InkCLIRenderer implements CLIRenderer {
         columns={this.columns.value}
         rows={this.rows.value}
         finalStatus={this.finalStatus.value}
-        useColor={this.options.useColor}
-        colorTheme={this.options.colorTheme}
-        onInterrupt={() => {
-          this.processSignalHandler();
-        }}
-      />
+      useColor={this.options.useColor}
+      colorTheme={this.options.colorTheme}
+      onInterrupt={() => {
+        this.processSignalHandler();
+      }}
+      onQuit={() => {
+        this.processQuitHandler();
+      }}
+    />
     );
 
     if (this.inkInstance) {

--- a/tests/ink-renderer.test.tsx
+++ b/tests/ink-renderer.test.tsx
@@ -5,6 +5,7 @@ import { DEFAULT_TASK_LOG_COLOR_THEME } from "../src/renderer-colors.js";
 import {
   InkRendererScreen,
   isInkInterruptInput,
+  isInkQuitInput,
   reduceInkUIState,
   type InkUIState
 } from "../src/ink-renderer.js";
@@ -178,6 +179,12 @@ describe("Ink renderer screen", () => {
     expect(isInkInterruptInput("c", { ctrl: false, name: "c" })).toBe(false);
   });
 
+  it("detects q as the explicit quit key", () => {
+    expect(isInkQuitInput("q", {})).toBe(true);
+    expect(isInkQuitInput("Q", {})).toBe(true);
+    expect(isInkQuitInput("q", { ctrl: true, name: "q" })).toBe(false);
+  });
+
   it("renders workflow flowchart, branch nesting, task durations, and logs", async () => {
     const state = createInkState();
     const instance = render(
@@ -276,6 +283,32 @@ describe("Ink renderer screen", () => {
       instance.stdin.write("\u0003");
       await flushInk();
       expect(interrupted).toBe(1);
+    } finally {
+      instance.unmount();
+    }
+  });
+
+  it("invokes the quit callback when q is pressed", async () => {
+    const state = createInkState();
+    let quitCount = 0;
+    const instance = render(
+      <InkRendererScreen
+        state={state}
+        columns={110}
+        rows={18}
+        finalStatus={undefined}
+        useColor={false}
+        colorTheme={DEFAULT_TASK_LOG_COLOR_THEME}
+        onQuit={() => {
+          quitCount += 1;
+        }}
+      />
+    );
+
+    try {
+      instance.stdin.write("q");
+      await flushInk();
+      expect(quitCount).toBe(1);
     } finally {
       instance.unmount();
     }

--- a/tests/renderer.test.ts
+++ b/tests/renderer.test.ts
@@ -516,4 +516,131 @@ describe("CLI renderer", () => {
     expect(summaryCalls).toBe(1);
     expect(exitCode).toBe(130);
   });
+
+  it("handles q by cancelling active workflows, then exiting cleanly when the run stops", async () => {
+    const ttyLike = stream as unknown as NodeJS.WriteStream & {
+      isTTY?: boolean;
+      columns?: number;
+      rows?: number;
+      on?: typeof stream.on;
+      off?: typeof stream.off;
+    };
+    ttyLike.isTTY = true;
+    ttyLike.columns = 100;
+    ttyLike.rows = 30;
+    ttyLike.on = ((..._args: Parameters<typeof stream.on>) => ttyLike) as typeof ttyLike.on;
+    ttyLike.off = ((..._args: Parameters<typeof stream.off>) => ttyLike) as typeof ttyLike.off;
+
+    let cancelCalls = 0;
+    let leaveCalls = 0;
+    let summaryCalls = 0;
+    let exitCode: number | undefined;
+
+    const renderer = new InkCLIRenderer({
+      enabled: true,
+      mode: "ink",
+      persistAfterCompletion: true,
+      stream: ttyLike,
+      errorStream: ttyLike,
+      workflowController: {
+        hasActiveRuns: () => true,
+        cancelActiveRuns: async () => {
+          cancelCalls += 1;
+          return 1;
+        }
+      }
+    }) as InkCLIRenderer & Record<string, unknown>;
+
+    renderer["attachResizeHandler"] = () => undefined;
+    renderer["attachDebugStream"] = () => undefined;
+    renderer["renderNow"] = () => undefined;
+    renderer["enterAlternateScreen"] = () => undefined;
+    renderer["leaveAlternateScreen"] = () => {
+      leaveCalls += 1;
+    };
+    renderer["writeFinalSummary"] = () => {
+      summaryCalls += 1;
+    };
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      return undefined as never;
+    }) as typeof process.exit;
+
+    try {
+      renderer.start();
+      const quitHandler = renderer["processQuitHandler"] as (() => void) | undefined;
+      quitHandler?.();
+      await Promise.resolve();
+      renderer.stop("success");
+    } finally {
+      process.exit = originalExit;
+    }
+
+    expect(cancelCalls).toBe(1);
+    expect(leaveCalls).toBe(1);
+    expect(summaryCalls).toBe(1);
+    expect(exitCode).toBe(0);
+  });
+
+  it("handles q by restoring the terminal and exiting immediately when idle", () => {
+    const ttyLike = stream as unknown as NodeJS.WriteStream & {
+      isTTY?: boolean;
+      columns?: number;
+      rows?: number;
+      on?: typeof stream.on;
+      off?: typeof stream.off;
+    };
+    ttyLike.isTTY = true;
+    ttyLike.columns = 100;
+    ttyLike.rows = 30;
+    ttyLike.on = ((..._args: Parameters<typeof stream.on>) => ttyLike) as typeof ttyLike.on;
+    ttyLike.off = ((..._args: Parameters<typeof stream.off>) => ttyLike) as typeof ttyLike.off;
+
+    let leaveCalls = 0;
+    let summaryCalls = 0;
+    let exitCode: number | undefined;
+
+    const renderer = new InkCLIRenderer({
+      enabled: true,
+      mode: "ink",
+      persistAfterCompletion: true,
+      stream: ttyLike,
+      errorStream: ttyLike,
+      workflowController: {
+        hasActiveRuns: () => false,
+        cancelActiveRuns: async () => 0
+      }
+    }) as InkCLIRenderer & Record<string, unknown>;
+
+    renderer["attachResizeHandler"] = () => undefined;
+    renderer["attachDebugStream"] = () => undefined;
+    renderer["renderNow"] = () => undefined;
+    renderer["enterAlternateScreen"] = () => undefined;
+    renderer["leaveAlternateScreen"] = () => {
+      leaveCalls += 1;
+    };
+    renderer["writeFinalSummary"] = () => {
+      summaryCalls += 1;
+    };
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      exitCode = code;
+      return undefined as never;
+    }) as typeof process.exit;
+
+    try {
+      renderer.start();
+      const quitHandler = renderer["processQuitHandler"] as (() => void) | undefined;
+      quitHandler?.();
+    } finally {
+      process.exit = originalExit;
+    }
+
+    expect(leaveCalls).toBe(1);
+    expect(summaryCalls).toBe(0);
+    expect(exitCode).toBe(0);
+  });
 });


### PR DESCRIPTION
## Summary\n- add explicit q quit handling to Ink mode\n- keep Ctrl+C behavior and route q through the same graceful cancellation path\n- update Ink docs and tests for the new quit key\n\n## Testing\n- npm run typecheck\n- npm test\n- sample-project: npm run start:sub:ink, then press q in a TTY session and verify exit